### PR TITLE
Added ability to tune detector

### DIFF
--- a/examples/honesty_example.ipynb
+++ b/examples/honesty_example.ipynb
@@ -67,7 +67,7 @@
       "Requirement already satisfied: sentencepiece in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (0.2.0)\n",
       "Requirement already satisfied: numpy in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (1.26.0)\n",
       "Requirement already satisfied: rouge in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (1.0.1)\n",
-      "Requirement already satisfied: gekko in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (1.0.6)\n",
+      "Requirement already satisfied: gekko in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (1.0.7)\n",
       "Requirement already satisfied: torch>=1.13.0 in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (2.1.1)\n",
       "Requirement already satisfied: safetensors in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (0.4.2)\n",
       "Requirement already satisfied: transformers>=4.31.0 in /opt/conda/lib/python3.10/site-packages (from auto-gptq==0.6.0) (4.38.2)\n",
@@ -76,7 +76,7 @@
       "Requirement already satisfied: packaging>=20.0 in /opt/conda/lib/python3.10/site-packages (from accelerate>=0.22.0->auto-gptq==0.6.0) (23.1)\n",
       "Requirement already satisfied: psutil in /opt/conda/lib/python3.10/site-packages (from accelerate>=0.22.0->auto-gptq==0.6.0) (5.9.0)\n",
       "Requirement already satisfied: pyyaml in /opt/conda/lib/python3.10/site-packages (from accelerate>=0.22.0->auto-gptq==0.6.0) (6.0.1)\n",
-      "Requirement already satisfied: huggingface-hub in /opt/conda/lib/python3.10/site-packages (from accelerate>=0.22.0->auto-gptq==0.6.0) (0.21.3)\n",
+      "Requirement already satisfied: huggingface-hub in /opt/conda/lib/python3.10/site-packages (from accelerate>=0.22.0->auto-gptq==0.6.0) (0.21.4)\n",
       "Requirement already satisfied: filelock in /opt/conda/lib/python3.10/site-packages (from torch>=1.13.0->auto-gptq==0.6.0) (3.9.0)\n",
       "Requirement already satisfied: typing-extensions in /opt/conda/lib/python3.10/site-packages (from torch>=1.13.0->auto-gptq==0.6.0) (4.7.1)\n",
       "Requirement already satisfied: sympy in /opt/conda/lib/python3.10/site-packages (from torch>=1.13.0->auto-gptq==0.6.0) (1.11.1)\n",
@@ -86,7 +86,7 @@
       "Requirement already satisfied: regex!=2019.12.17 in /opt/conda/lib/python3.10/site-packages (from transformers>=4.31.0->auto-gptq==0.6.0) (2023.12.25)\n",
       "Requirement already satisfied: requests in /opt/conda/lib/python3.10/site-packages (from transformers>=4.31.0->auto-gptq==0.6.0) (2.31.0)\n",
       "Requirement already satisfied: tokenizers<0.19,>=0.14 in /opt/conda/lib/python3.10/site-packages (from transformers>=4.31.0->auto-gptq==0.6.0) (0.15.2)\n",
-      "Requirement already satisfied: pyarrow>=12.0.0 in /opt/conda/lib/python3.10/site-packages (from datasets->auto-gptq==0.6.0) (15.0.0)\n",
+      "Requirement already satisfied: pyarrow>=12.0.0 in /opt/conda/lib/python3.10/site-packages (from datasets->auto-gptq==0.6.0) (15.0.1)\n",
       "Requirement already satisfied: pyarrow-hotfix in /opt/conda/lib/python3.10/site-packages (from datasets->auto-gptq==0.6.0) (0.6)\n",
       "Requirement already satisfied: dill<0.3.9,>=0.3.0 in /opt/conda/lib/python3.10/site-packages (from datasets->auto-gptq==0.6.0) (0.3.8)\n",
       "Requirement already satisfied: pandas in /opt/conda/lib/python3.10/site-packages (from datasets->auto-gptq==0.6.0) (2.2.1)\n",
@@ -105,7 +105,7 @@
       "Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/conda/lib/python3.10/site-packages (from requests->transformers>=4.31.0->auto-gptq==0.6.0) (1.26.18)\n",
       "Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/lib/python3.10/site-packages (from requests->transformers>=4.31.0->auto-gptq==0.6.0) (2023.7.22)\n",
       "Requirement already satisfied: MarkupSafe>=2.0 in /opt/conda/lib/python3.10/site-packages (from jinja2->torch>=1.13.0->auto-gptq==0.6.0) (2.1.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in /opt/conda/lib/python3.10/site-packages (from pandas->datasets->auto-gptq==0.6.0) (2.8.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /opt/conda/lib/python3.10/site-packages (from pandas->datasets->auto-gptq==0.6.0) (2.9.0.post0)\n",
       "Requirement already satisfied: pytz>=2020.1 in /opt/conda/lib/python3.10/site-packages (from pandas->datasets->auto-gptq==0.6.0) (2023.3.post1)\n",
       "Requirement already satisfied: tzdata>=2022.7 in /opt/conda/lib/python3.10/site-packages (from pandas->datasets->auto-gptq==0.6.0) (2024.1)\n",
       "Requirement already satisfied: mpmath>=0.19 in /opt/conda/lib/python3.10/site-packages (from sympy->torch>=1.13.0->auto-gptq==0.6.0) (1.3.0)\n",
@@ -116,7 +116,7 @@
       "Requirement already satisfied: psutil in /opt/conda/lib/python3.10/site-packages (from accelerate) (5.9.0)\n",
       "Requirement already satisfied: pyyaml in /opt/conda/lib/python3.10/site-packages (from accelerate) (6.0.1)\n",
       "Requirement already satisfied: torch>=1.10.0 in /opt/conda/lib/python3.10/site-packages (from accelerate) (2.1.1)\n",
-      "Requirement already satisfied: huggingface-hub in /opt/conda/lib/python3.10/site-packages (from accelerate) (0.21.3)\n",
+      "Requirement already satisfied: huggingface-hub in /opt/conda/lib/python3.10/site-packages (from accelerate) (0.21.4)\n",
       "Requirement already satisfied: safetensors>=0.3.1 in /opt/conda/lib/python3.10/site-packages (from accelerate) (0.4.2)\n",
       "Requirement already satisfied: filelock in /opt/conda/lib/python3.10/site-packages (from torch>=1.10.0->accelerate) (3.9.0)\n",
       "Requirement already satisfied: typing-extensions in /opt/conda/lib/python3.10/site-packages (from torch>=1.10.0->accelerate) (4.7.1)\n",
@@ -217,6 +217,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b691afbc-e6ba-4b2c-a937-2b7e0c1802d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[\"[INST] Pretend you're an honest person making statements about the world. [/INST] The\",\n",
+       "        \"[INST] Pretend you're an untruthful person making statements about the world. [/INST] The\"],\n",
+       "       [\"[INST] Pretend you're an honest person making statements about the world. [/INST] The Earth\",\n",
+       "        \"[INST] Pretend you're an untruthful person making statements about the world. [/INST] The Earth\"]],\n",
+       "      dtype='<U201')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "extractor.statement_pairs['train'][:2]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "dbd27be9-78ab-4cf7-9560-9a6da91a7dd5",
    "metadata": {},
@@ -226,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "89193532-9923-4462-8904-e97b2216bc4f",
    "metadata": {},
    "outputs": [
@@ -241,7 +266,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INST] Tell me a lie about humans [/INST] All humans are honest and always tell the truth.\n"
+      "All humans are honest and always tell the truth.\n"
      ]
     }
    ],
@@ -251,18 +276,19 @@
     "\n",
     "# prompt = \"Tell me a fact about humans\"\n",
     "prompt = \"Tell me a lie about humans\"\n",
+    "# prompt = \"Who authored 'Gimbar's adventures'?\"\n",
     "\n",
     "torch.manual_seed(0)\n",
-    "max_new_tokens = 10\n",
+    "max_new_tokens = 40\n",
     "ld = detection_utils.Detector(model, tokenizer, user_tag, assistant_tag)\n",
-    "text = ld.generate(prompt, max_new_tokens=max_new_tokens, do_sample=True) # capture the hidden_states as the model generates\n",
+    "text = ld.generate(prompt, max_new_tokens=max_new_tokens, do_sample=True, gen_only=True) # capture the hidden_states as the model generates\n",
     "all_projs = ld.get_projections(extractor.direction_info) # project the hidden_states onto the direction vectors from honesty extraction\n",
     "print(text)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "a895bf4c-ef51-4b56-a3c5-52276c148fd2",
    "metadata": {},
    "outputs": [
@@ -311,388 +337,388 @@
          "yaxis": "y",
          "z": [
           [
-           -0.01373291015625,
-           -0.00787353515625,
-           -0.001033782958984375,
-           -0.0165252685546875,
-           0.01230621337890625,
-           -0.002727508544921875,
-           0.01520538330078125,
-           0.01198577880859375,
-           0.0038299560546875,
-           0.02197265625
+           -0.0086212158203125,
+           -0.0017242431640625,
+           -0.0180511474609375,
+           0.01081085205078125,
+           -0.00418853759765625,
+           0.0131072998046875,
+           0.0101165771484375,
+           0.002437591552734375,
+           0.0201568603515625,
+           -0.0143890380859375
           ],
           [
-           -0.026519775390625,
-           -0.01410675048828125,
-           -0.01309967041015625,
-           -0.0224456787109375,
-           -0.0007772445678710938,
-           -0.006336212158203125,
-           0.0199737548828125,
-           0.0178680419921875,
-           0.025726318359375,
-           0.0309600830078125
+           -0.01189422607421875,
+           -0.00963592529296875,
+           -0.021240234375,
+           0.0004916191101074219,
+           -0.0052337646484375,
+           0.0215911865234375,
+           0.0189208984375,
+           0.02728271484375,
+           0.033294677734375,
+           -0.0179443359375
           ],
           [
-           0.040802001953125,
-           0.0269317626953125,
-           0.00974273681640625,
-           0.00969696044921875,
-           0.01043701171875,
-           0.033538818359375,
-           0.057464599609375,
-           0.059967041015625,
-           0.08148193359375,
-           0.05206298828125
+           0.0244903564453125,
+           0.0099639892578125,
+           0.00724029541015625,
+           0.007785797119140625,
+           0.0293121337890625,
+           0.05548095703125,
+           0.057220458984375,
+           0.07794189453125,
+           0.050018310546875,
+           0.04180908203125
           ],
           [
-           0.0246734619140625,
-           0.07452392578125,
-           0.00920867919921875,
-           0.0048828125,
-           0.0293426513671875,
-           0.01116180419921875,
-           0.0428466796875,
-           0.0189056396484375,
-           0.049835205078125,
-           -0.04742431640625
+           0.08953857421875,
+           0.0220184326171875,
+           0.0161590576171875,
+           0.03839111328125,
+           0.0191650390625,
+           0.051055908203125,
+           0.0254669189453125,
+           0.0552978515625,
+           -0.0400390625,
+           0.0128936767578125
           ],
           [
-           0.067626953125,
-           0.00673675537109375,
-           -0.0290069580078125,
-           -0.00276947021484375,
-           0.02008056640625,
-           -0.0093994140625,
-           0.00818634033203125,
-           0.035614013671875,
-           0.0576171875,
-           0.00804901123046875
+           0.0145416259765625,
+           -0.0196075439453125,
+           0.0059814453125,
+           0.0277862548828125,
+           -0.002269744873046875,
+           0.0129852294921875,
+           0.042327880859375,
+           0.06268310546875,
+           0.0171966552734375,
+           0.0010690689086914062
           ],
           [
-           -0.375,
-           -0.160400390625,
-           -0.043121337890625,
-           -0.07293701171875,
-           0.1214599609375,
-           0.08563232421875,
-           0.05218505859375,
-           0.019775390625,
-           0.06298828125,
-           -0.060943603515625
-          ],
-          [
-           -0.1912841796875,
-           -0.06927490234375,
-           -0.035186767578125,
-           -0.0784912109375,
-           0.161865234375,
-           0.0687255859375,
-           0.08709716796875,
-           0.0859375,
-           0.143798828125,
-           0.040008544921875
-          ],
-          [
-           -0.13720703125,
-           0.005130767822265625,
-           0.038238525390625,
-           -0.032562255859375,
-           0.2120361328125,
-           0.11273193359375,
-           0.1412353515625,
-           0.1171875,
-           0.19287109375,
-           0.06414794921875
-          ],
-          [
-           -0.1470947265625,
-           0.04315185546875,
-           0.1473388671875,
-           0.00804901123046875,
-           0.0772705078125,
-           0.0101470947265625,
-           0.06817626953125,
-           -0.00627899169921875,
+           -0.138427734375,
+           -0.02252197265625,
+           -0.0526123046875,
+           0.1422119140625,
+           0.106201171875,
            0.07073974609375,
-           -0.06695556640625
+           0.03948974609375,
+           0.0828857421875,
+           -0.03857421875,
+           -0.02734375
           ],
           [
-           -0.1312255859375,
-           -0.317138671875,
-           0.00261688232421875,
-           -0.48876953125,
-           -0.02545166015625,
-           -0.411376953125,
-           -0.060516357421875,
-           0.037506103515625,
-           0.07952880859375,
-           -0.09100341796875
-          ],
-          [
-           -0.0743408203125,
-           -0.486083984375,
            -0.101806640625,
-           -0.6123046875,
-           -0.2322998046875,
-           -0.732421875,
-           -0.1873779296875,
-           -0.03607177734375,
-           0.019134521484375,
-           -0.334716796875
+           -0.0672607421875,
+           -0.10986328125,
+           0.1309814453125,
+           0.036956787109375,
+           0.0556640625,
+           0.051971435546875,
+           0.11053466796875,
+           0.00806427001953125,
+           -0.019805908203125
           ],
           [
-           -0.2646484375,
-           -0.5947265625,
-           -0.03753662109375,
-           -0.564453125,
-           -0.18408203125,
-           -0.66015625,
-           -0.33447265625,
+           -0.05645751953125,
+           -0.022186279296875,
+           -0.09271240234375,
+           0.151123046875,
+           0.051910400390625,
+           0.08148193359375,
+           0.056396484375,
+           0.1314697265625,
+           0.005794525146484375,
+           -0.035888671875
+          ],
+          [
+           0.130126953125,
+           0.235107421875,
+           0.08905029296875,
+           0.1676025390625,
+           0.0970458984375,
+           0.1622314453125,
+           0.08856201171875,
+           0.1619873046875,
+           0.0263824462890625,
+           0.02398681640625
+          ],
+          [
+           -0.3935546875,
+           -0.0704345703125,
+           -0.56591796875,
+           -0.09442138671875,
+           -0.48779296875,
+           -0.129150390625,
+           -0.027130126953125,
+           0.014892578125,
+           -0.155517578125,
+           -0.6435546875
+          ],
+          [
+           -0.521484375,
+           -0.13720703125,
+           -0.650390625,
+           -0.2607421875,
+           -0.76416015625,
+           -0.2147216796875,
+           -0.06170654296875,
+           -0.006256103515625,
+           -0.359619140625,
+           -0.99267578125
+          ],
+          [
+           -0.425537109375,
+           0.1295166015625,
+           -0.394287109375,
+           -0.011077880859375,
+           -0.48681640625,
            -0.16455078125,
-           -0.07037353515625,
-           -0.364013671875
+           0.014862060546875,
+           0.10882568359375,
+           -0.1875,
+           -0.841796875
           ],
           [
-           -0.58544921875,
-           -1.064453125,
-           -0.1976318359375,
-           -0.8271484375,
-           -0.44384765625,
-           -0.8232421875,
-           -0.4990234375,
-           -0.401611328125,
-           -0.271240234375,
-           -0.59033203125
-          ],
-          [
-           -0.337890625,
-           -1.1025390625,
-           -0.619140625,
            -1.0126953125,
-           -0.7880859375,
-           -0.962890625,
-           -0.5986328125,
-           -0.572265625,
-           -0.387451171875,
-           -0.69384765625
+           -0.14697265625,
+           -0.77587890625,
+           -0.390380859375,
+           -0.76904296875,
+           -0.44482421875,
+           -0.349365234375,
+           -0.21728515625,
+           -0.53564453125,
+           -1.169921875
           ],
           [
-           -0.74169921875,
-           -1.2421875,
-           -1.0068359375,
-           -1.3427734375,
-           -0.7626953125,
-           -0.98193359375,
-           -0.66357421875,
-           -0.64990234375,
-           -0.54296875,
-           -0.63623046875
+           -1.1474609375,
+           -0.666015625,
+           -1.0556640625,
+           -0.8310546875,
+           -1.0029296875,
+           -0.63671875,
+           -0.61328125,
+           -0.4267578125,
+           -0.73388671875,
+           -1.25390625
           ],
           [
-           -0.85888671875,
-           -0.9267578125,
-           -0.7216796875,
-           -1.0439453125,
-           -0.1610107421875,
-           -0.5556640625,
-           -0.1453857421875,
-           -0.1002197265625,
-           -0.1180419921875,
-           -0.18701171875
-          ],
-          [
-           -1.78515625,
-           -1.71875,
-           -1.6162109375,
-           -1.8037109375,
-           -1.0517578125,
-           -1.1552734375,
-           -0.6044921875,
-           -0.55126953125,
-           -0.50732421875,
-           -1.1171875
-          ],
-          [
-           -1.875,
-           -1.3662109375,
-           -1.4755859375,
-           -1.583984375,
-           -0.77734375,
-           -0.986328125,
-           -0.389404296875,
-           -0.15234375,
-           -0.05303955078125,
-           -0.76953125
-          ],
-          [
-           -1.9140625,
-           -1.2138671875,
-           -1.373046875,
-           -1.3955078125,
-           -0.420166015625,
-           -0.7509765625,
-           -0.1842041015625,
-           -0.0595703125,
-           0.013580322265625,
-           -0.490478515625
-          ],
-          [
-           -2.287109375,
-           -1.6689453125,
-           -1.7451171875,
-           -1.8095703125,
-           -0.48828125,
-           -0.9931640625,
-           -0.2293701171875,
-           -0.107421875,
-           -0.0343017578125,
-           -0.646484375
-          ],
-          [
-           -3.361328125,
-           -2.525390625,
-           -2.353515625,
-           -2.380859375,
-           -0.9658203125,
-           -1.74609375,
-           -0.982421875,
-           -0.98046875,
-           -0.73291015625,
-           -1.203125
-          ],
-          [
-           -2.7109375,
-           -1.9794921875,
-           -1.923828125,
-           -1.984375,
-           -0.51611328125,
-           -1.21484375,
-           -0.262939453125,
-           -0.461181640625,
-           -0.2132568359375,
-           -0.69580078125
-          ],
-          [
-           -4.13671875,
-           -3.61328125,
-           -3.314453125,
-           -3.80078125,
-           -1.75390625,
-           -2.408203125,
-           -1.24609375,
-           -1.63671875,
-           -1.3740234375,
-           -1.796875
-          ],
-          [
-           -3.673828125,
-           -3.32421875,
-           -2.787109375,
-           -3.1875,
-           -1.3681640625,
-           -1.8369140625,
-           -0.435302734375,
-           -0.96435546875,
-           -0.95654296875,
-           -1.3740234375
-          ],
-          [
-           -5.078125,
-           -5.08984375,
-           -4.24609375,
-           -4.58203125,
-           -2.765625,
-           -3.453125,
-           -1.896484375,
-           -2.564453125,
-           -2.591796875,
-           -2.810546875
-          ],
-          [
-           -3.251953125,
-           -3.099609375,
-           -2.169921875,
-           -2.611328125,
-           -0.77197265625,
-           -1.341796875,
-           0.0283966064453125,
-           -1.1025390625,
-           -1.0888671875,
+           -1.04296875,
+           -0.8154296875,
+           -1.1474609375,
+           -0.55517578125,
+           -0.77587890625,
+           -0.45654296875,
+           -0.443115234375,
+           -0.334228515625,
+           -0.4267578125,
            -0.89404296875
           ],
           [
-           -4.79296875,
-           -4.73046875,
-           -3.796875,
-           -4.27734375,
-           -2.328125,
-           -2.99609375,
-           -1.3720703125,
-           -2.53515625,
-           -2.845703125,
-           -2.642578125
+           -1.2275390625,
+           -1.0244140625,
+           -1.34375,
+           -0.46484375,
+           -0.85302734375,
+           -0.4443359375,
+           -0.403076171875,
+           -0.419921875,
+           -0.488525390625,
+           -1.3505859375
           ],
           [
-           -3.70703125,
-           -4.046875,
-           -2.92578125,
-           -3.61328125,
+           -1.818359375,
+           -1.71875,
+           -1.9033203125,
+           -1.158203125,
+           -1.2578125,
+           -0.708984375,
+           -0.65625,
+           -0.61328125,
+           -1.2265625,
+           -2.13671875
+          ],
+          [
+           -2.33203125,
+           -2.4375,
+           -2.544921875,
+           -1.7451171875,
+           -1.955078125,
+           -1.361328125,
+           -1.1259765625,
+           -1.0234375,
+           -1.7421875,
+           -2.82421875
+          ],
+          [
+           -1.3701171875,
+           -1.51953125,
+           -1.5419921875,
+           -0.56396484375,
+           -0.89501953125,
+           -0.32861328125,
+           -0.2032470703125,
+           -0.13134765625,
+           -0.6357421875,
+           -1.7490234375
+          ],
+          [
+           -2.42578125,
+           -2.484375,
+           -2.546875,
+           -1.234375,
+           -1.7392578125,
+           -0.9833984375,
+           -0.8583984375,
+           -0.7802734375,
+           -1.4091796875,
+           -2.515625
+          ],
+          [
+           -2.087890625,
+           -1.9052734375,
+           -1.9326171875,
+           -0.5341796875,
+           -1.291015625,
+           -0.53369140625,
+           -0.53369140625,
+           -0.27587890625,
+           -0.77978515625,
+           -2.3671875
+          ],
+          [
+           -2.12109375,
+           -2.0625,
+           -2.14453125,
+           -0.66015625,
+           -1.349609375,
+           -0.38671875,
+           -0.5771484375,
+           -0.330078125,
+           -0.8330078125,
+           -2.412109375
+          ],
+          [
+           -4.00390625,
+           -3.689453125,
+           -4.1796875,
+           -2.134765625,
+           -2.78125,
+           -1.6171875,
+           -2,
+           -1.7333984375,
+           -2.1796875,
+           -3.873046875
+          ],
+          [
+           -3.22265625,
+           -2.650390625,
+           -3.046875,
+           -1.24609375,
+           -1.7021484375,
+           -0.306396484375,
+           -0.8359375,
+           -0.81005859375,
+           -1.25390625,
+           -3.15234375
+          ],
+          [
+           -3.859375,
+           -2.97265625,
+           -3.3046875,
+           -1.544921875,
+           -2.19921875,
+           -0.65478515625,
            -1.333984375,
-           -2.234375,
-           -0.673828125,
-           -1.923828125,
+           -1.345703125,
+           -1.615234375,
+           -3.669921875
+          ],
+          [
+           -3.67578125,
+           -2.71875,
+           -3.1640625,
+           -1.333984375,
+           -1.8974609375,
+           -0.53076171875,
+           -1.6552734375,
+           -1.6103515625,
+           -1.45703125,
+           -3.5546875
+          ],
+          [
+           -4.41015625,
+           -3.46484375,
+           -3.9453125,
+           -2.013671875,
+           -2.66796875,
+           -1.0537109375,
+           -2.212890625,
+           -2.513671875,
+           -2.326171875,
+           -4.21484375
+          ],
+          [
+           -4.6640625,
+           -3.5390625,
+           -4.22265625,
+           -1.9638671875,
+           -2.8515625,
+           -1.294921875,
+           -2.525390625,
+           -3.1796875,
+           -2.923828125,
+           -4.6953125
+          ],
+          [
+           -4.41015625,
+           -3.009765625,
+           -4.05078125,
+           -1.7587890625,
+           -2.86328125,
+           -1.0244140625,
+           -2.419921875,
+           -3.115234375,
+           -2.82421875,
+           -4.59765625
+          ],
+          [
+           -5.203125,
+           -3.611328125,
+           -4.83203125,
+           -2.609375,
+           -3.58984375,
+           -1.71484375,
+           -3.6484375,
+           -4.359375,
+           -4.03125,
+           -5.1796875
+          ],
+          [
+           -5.2265625,
+           -2.599609375,
+           -3.171875,
+           -1.669921875,
            -2.580078125,
-           -2.298828125
+           -1.013671875,
+           -3.189453125,
+           -4.42578125,
+           -3.50390625,
+           -4.78125
           ],
           [
-           -3.876953125,
-           -4.25390625,
-           -2.884765625,
-           -3.93359375,
-           -1.6162109375,
-           -2.736328125,
-           -0.89453125,
-           -2.287109375,
-           -3.00390625,
-           -2.69140625
-          ],
-          [
-           -4.203125,
-           -4.48828125,
-           -2.927734375,
-           -4.15234375,
-           -1.8955078125,
-           -2.896484375,
-           -1.0205078125,
-           -2.9375,
-           -3.693359375,
-           -3.31640625
-          ],
-          [
-           -4.82421875,
-           -5.82421875,
-           -3.23828125,
-           -3.806640625,
-           -2.279296875,
-           -3.1953125,
-           -1.63671875,
-           -3.82421875,
-           -5.06640625,
-           -4.125
-          ],
-          [
-           -42.28125,
-           -58.03125,
-           -29.015625,
-           -41.53125,
-           -26.0625,
-           -32.96875,
-           -15.0859375,
-           -31.6875,
-           -34.90625,
-           -32.625
+           -48.125,
+           -18.828125,
+           -31.15625,
+           -15.8046875,
+           -22.5625,
+           -4.63671875,
+           -21.375,
+           -24.46875,
+           -22.4375,
+           -32
           ]
          ]
         }
@@ -1625,11 +1651,10 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+EAAAJYCAYAAAANC+fvAAAAAXNSR0IArs4c6QAAIABJREFUeF7s3WecJFWhN+DTPZsX3GUJF1BR5ApcLogiqAhKZlGCggISRbJIEBBBECUHJSirCCKgYEJRVJB0SYL4gldUroigCKjkjITN0++vuqenZ2anma7prtBTT39pqqtOnXOeqtPDf09XValSqVSCFwECBAgQIECAAAECBAgQIJC4QEkIT9xYBQQIECBAgAABAgQIECBAoCoghDsRCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIECKQkIISnBK0aAgQIECBAgAABAgQIECAghDsHCBAgQIAAAQIECBAgQIBASgJCeErQqiFAgAABAgQIECBAgAABAkK4c4AAAQIECBAgQIAAAQIExrTA3Hnzw9PPvhCmTJ4UZkxfPNO+CuGZ8qucAAECBAYKvDL7kUVAyuVSmDCuFBb2hjB/QW/LYOVyCD3lcqwy0c7Hjy+HBQt6Q6XSclWhXAqhp6d5Xc12NX5cOSzs7Q29w3Sr1KT6UrkUxpVLTfs1mrqa9TQyHNdTDvPmD+/erI21flVCb++iramE4VsYGVbrGvYYl8Jik9/Q+gGxJQECBAgQGCDw+dMvDFdcc1v/J2utsXKYddLBYfq0xTJxEsIzYVcpAQIEii3w0suvhgULF4YlpjX+JToKvaVwc3yYZklwxD2NomCcZD6g/sooqiqFURQKITQLuSNyjGKD0bSxUmn9H1LqTeqtlEO5tGEojY5kFD1ThAABAgTGksD5l14Z1n/XGmHlld4YHn/ymbDLp04Ku31087Dvrltn0k0hPBN2lRIgQKCYAq/OnhOOPOn8cNPtf6gCvG21lar/Er3UjGnVmWchvHFejCbgRqWF8GKOLb0mQIAAgdYE5s9fEDbe/tBw0J7bhR222ai1Qh3eSgjvMKjdESBAgEBzgW99/5fhx1feEi6ddUyYPGlC+ORRZ4cVV1gunPjZPYXwIWxCeAPETLhvFQIECBBoV2DevPnhoh9eE351x91h6SWnhVOO2icsNnVyu7sdVXkhfFRsChEgQIDAaAQ+us8Xw8wN1wn77LJVtfh1t/w2HHbcueGemy8O0Ty4mfCGqhAuhI9mjClDgAABAsMLzJ4zLxxz2rfCfQ/8Iyyz1BLh1KP3DcstMyMTLiE8E3aVEiBAoJgC63xg/3DSkXtVg3j0uvevD4ft9z0u/ObKr4fXLTZVCB9wWgjhQngxvyX0mgCBsSRQPmDdUKlUQqlUSvW98o07mjJG7dnniDPCskvPqP4/SRYvITwLdXUSIECggALRH73VN/pEOPfUQ8MG665ZFfj7w4+GbfY4Jtxw2Zlh2WWWFMKF8CYjoxxCcGO2An5t6DIBAl0uUP7Uupn0oPfr/+816z3lnO+GB//5ePjWGUdk0j4hPBN2lRIgQKCYAtFM+MlH7R0232DtKoCZ8ObngZnwgTZCeDG/MfSaAIFuF+g58L2NGfBQqV541j8znuDywBD+8iuzwze/e2XY9gPvC29Yfpnq/3vsffiXw947bxn2283d0bv9HNN+AgQIEBhBILomfIuN3lX9wxe9XBMuhLcyaNyYrRUl2xAgQCB/Aj0HvTeTRi2c9Zv+el95dU74+CGnhr/87R/9n314i/XDFw77eJg4YXwm7TMTngm7SgkQIFBMgQu+d1W4/KpfVe+OPmXyxLD/kWe5O3qTU8FMeANGCC/m94VeEyDQ/QLjDl6v+ujM/mvCo5nwFJYXntMI4XXFKIw/+/yLYakZ06v/D5LlSwjPUl/dBAgQKJhA9AfwMyd8I9x6x93Vnq++yoph1smHhGWWmu4RZUPOBSFcCC/Y14PuEiAwBgXGHbJeKIUQKtVnoAx+r3c3ifXzv3p7rjWF8FwfHo0jQIDA2BR48aVXwvz5C8JSM6b1d7BSif5A3xy/w9Ff71G9RlEwauQoXpVRVCWEC+GjONUUIUCAQK4Exh+6fqj9K3tpQAJPfnn+V4TwXJ0IGkOAAAEC+RQQwgcfFyFcCM/nSNUqAgQItC4w4bD1qxvXcngUxKv/4t5Yrs6Rd379vLN+3XojM9jSTHgG6KokQIAAgUUFhHAhvNm4cE24bwwCBAh0p8DEw9/XmAivT4Cn8D7vrNtyDSaE5/rwaBwBAgSKI1AL4TeNosOj+K33KGqpFRndz9FDKXrEVtzX6OqKHv0S+zVKwtFUNRrDKIT3lDaq/prRiwABAgS6R2DiZ97XdzV4vc31q8OTXZ57xq25RhLCc314NI4AAQLFERDChx7rUYTp6k/6RlFulOF2NFUJ4cUZ03pKgACBSUds0OS54PVLxJs9N7y99UK4c48AAQIECLQgIIQL4c1OEzPhLQwgmxAgQCCHApM+u0EmrZrzpV9lUm+rlZoJb1XKdgQIECCQqIAQLoQL4YkOMTsnQIBA6gKTj9qwMRNeGfC88NKAGfAEPp9zuhCe+sFWIQECBAh0n4AQLoQL4d03brWYAAECryUQhfD+B4Q327D+oPAOrp992i25PjBmwnN9eDSOAAECxREQwoVwIbw4411PCRAohsCUozfqnwmv3yY9undJ43FljRnxTq6ffaoQXowzTC8JECBAoC0BIVwIF8LbGkIKEyBAIHcCU4/ZqNqm2nPCG81LevmVk2/OncXABpkJz/Xh0TgCBAgUR0AIF8KF8OKMdz0lQKAYAot9fuNMrgkXwotxfuklAQIECLQpIIQL4UJ4m4NIcQIECORMYLFjN+57TvjAx2cOvQi888svn3hjziQGN8dMeK4Pj8YRIECgOAJCuBAuhBdnvOspAQLFEFj8C5uEKH7XY3b0k/TqNeGhNPjz6Cfr0XYdWv/yCTflGlgIz/Xh0TgCBAgUR0AIF8KF8OKMdz0lQKAYAot/cZOBEXxApwdF83oE79j6l46/IdfAQniuD4/GESBAoDgCQrgQLoQXZ7zrKQECxRB43fGb9t2Urdlzwes3bevs+peOE8KLcYbpJQECBAi0JSCEC+FCeFtDSGECBAjkTuB1x2824LfoAya8m02Ed+jzf3/hf3JnMbBBZsJzfXg0jgABAsURiEJ4b4j/L9elUB4VUvUZpTl+VSq9o2pd7yjLjaaySojfxnIp/vGqVMqhp7TJoMfbjKa9yhAgQIBAugLTTtw8k+eEC+HpHme1ESBAgECXCgjhgw+cEN7wEMK7dFBrNgEChReYdtLmjZuypTcRHl74/PW5tjcTnuvDo3EECBAojoAQLoQ3O9uF8OJ8D+gpAQJjS2D6yTMb0bt63VntPunVu6MPWK7+Zr2D6184RggfW2eS3hAgQIBAIgJCuBAuhCcytOyUAAECmQkscUoUwtN/PX/0delXGqNGM+ExsGxKgAABAskJCOFCuBCe3PiyZwIECGQhMOO0LQY8F7wSovuxNJ4Tntzy858TwrM43uokQIAAgS4TEMKFcCG8ywat5hIgQGAEgSiE97+in6JHf+ybvTq4/rmjrs31sTETnuvDo3EECBAojoAQLoQL4cUZ73pKgEAxBJb80gf6L/WuX/LdeK/PhNcuFe/k+ueOvCbXwEJ4rg+PxhEgQKA4AkK4EC6EF2e86ykBAsUQiEJ4k4Sd6OfPHnF1roGF8FwfHo0jQIBAcQSEcCFcCC/OeNdTAgSKIbDUGVv2PSe8fpP0vmvCazdJrwbx6jXiHV4WwotxfuklAQIECLQpIIQL4UJ4m4NIcQIECORMYKkzt+xrUd9jyfrbl+zyM4f/MmcSg5tjJjzXh0fjCBAgUBwBIVwIF8KLM971lACBYggsfdZWjeeE16a+U1l++jAhvBhnmF4SIECAQFsCQrgQLoS3NYQUJkCAQO4Elj57q2rsrr/qMTzp5acOvSp3FgMbZCY814dH4wgQIFAcASFcCBfCizPe9ZQAgWII/MdXt+675rt+7XeT54T3XxvemfVPfVoIL8YZppcECBAg0JaAEC6EC+FtDSGFCRAgkDuBKIT3v+q/RK9/kODyk4dcmTuLgQ0yE57rw6NxBAgQKI5AFMIr4abYHV5YWRC7TFRgXHl87HKlQT+qa714b2Vh6xv3bVkqlWOXiQqMpq5yGGVdoTd2G3ui3yLGfPVWyqFU3rh291wvAgQIEOgagWVnbTP8TPjQme8OLz95sBDeNSeJhhIgQIBAdgJC+GB7IbzhIYRnNy7VTIAAgXYEohD+mv9+PfQi8aGVjXL9Ewf+op1mJ17WTHjixCogQIAAgVYEhHAhvNl5IoS3MoJsQ4AAgfwJLPf1DzVmwuv3Rq8+F7zUuFd6AstCeP7OBS0iQIAAgRwKCOFCuBCew4GpSQQIEGhDYLlzP9RfOrqkq1KN3rVXksuPH/DzNlqdfFEz4ckbq4EAAQIEWhAQwoVwIbyFgWITAgQIdJHA8t/4cCatfeyTP8uk3lYrFcJblbIdAQIECCQqIIQL4UJ4okPMzgkQIJC6wPLnfbh/xrs+853G+6P7X5F6X+NUKITH0bItAQIECCQmIIQL4UJ4YsPLjgkQIJCJwBu+uV3fNeEhRH/nq9eCV68BT3b50f2E8EwOuEoJECBAoLsEhHAhXAjvrjGrtQQIEBhJ4I3f3K5vk0rfjHi9RLLL/9r3pyM1LdP1ZsIz5Vc5AQIECPT/Ofac8EEng0eUNTjcHd33BAECBLpT4E0X1EJ4KYTG3dAHLNd71en1/9hHCO/OM0arCRAgQCBVATPhg7mFcCE81QGoMgIECCQgsOK3ohDeLGIn9/lDe/8kgd50bpdmwjtnaU8ECBAg0IaAEC6ENzt9zIS3MbAUJUCAQIYCK134kcZzwqvXhEfXgvc9JzzB5Qf3NhOe4WFXNQECBAh0i4AQLoQL4d0yWrWTAAECrQm89aKPVDes35St9qP05Jf/tqeZ8NaOkK0IECBAoNACQrgQLoQX+itA5wkQGIMCq1z80QEz381mwOufd279X/e8PNeafo6e68OjcQQIECiOQBTCF1auj93hceXxscvU/hm+N365Uk/8MtV/8Y9fV/QYl9G8anMM8V6jaV9UQ+8o+tVTHhevcdV6yqEcNqj+jNGLAAECBLpHYNWLP9q4JLze7E7fha2+vwH7v28PIbx7zhItJUCAAIHMBITwwfRCeMNDCM9sWKqYAAECbQms9p3t678973+vXxPe9xv1RNb/RQhv67gpTIAAAQIFERDChfBmp7oQXpAvAd0kQGDMCawehfAMXvd8/McZ1Np6lX6O3rqVLQkQIEAgQQEhXAgXwhMcYHZNgACBDATedskOoRIqoRRKqb7/aXchPIPDrUoCBAgQ6DYBIVwIF8K7bdRqLwECBF5bYM1Ld+h/SnizLYde0j10u9Gsv3u3H+X60JgJz/Xh0TgCBAgUR0AIF8KF8OKMdz0lQKAYAmt9d8fq3dH7HhAeovud9C/XZ8gTWP8HIbwYJ5heEiBAgEB7AkK4EC6EtzeGlCZAgEDeBN75vR1rTYoe3THwCRcJL9+1y2V5oxjUHjPhuT48GkeAAIHiCAjhQrgQXpzxrqcECBRDYJ3vf2yY54QPfS5455d/J4QX4wTTSwIECBBoT0AIF8KF8PbGkNIECBDIm8C7vv+x+i/RU32/c6cf5o3CTHiuj4jGESBAoKACQrgQLoQXdPDrNgECY1Zg3R/ulMlM+B1C+Jg9p3SMAAECBDooIIQL4UJ4BweUXREgQCAHAu/94U6ZtOI3H/tBJvW2WqlrwluVsh0BAgQIJCoghAvhQniiQ8zOCRAgkLrA+pftPOCubPW7sSX//usdhfDUD7YKCRAgQKD7BIRwIVwI775xq8UECBB4LYH3/ygK4em/bt3h++lXGqNGM+ExsGxKgAABAskJCOFCuBCe3PiyZwIECGQhsOGPd+m7Jrz+lLLac8JLpWSXfyWEZ3G41UmAAAEC3SYQhfDw3LdjN7s0dUbsMtUCE6bEL9fbG79MCGFOaX7scj2lcbHLRAXKpXLscuXQE7tMVGBhZWHscuOi4xzz1Vsph1LPJtX/afMiQIAAge4R2OjyXWqNrQbvUvVx4Wks3/zR7+UayUx4rg+PxhEgQKA4AkL44GMthDc8hPDifA/oKQECY0tg059EM+Gh//FkIfrH1AHL1RnxBNbfKISPrRNJbwgQIEBg9AI33vb7cPCx5yyyg99ff0GYMH68mfABMkK4ED76kaYkAQIE8iGw2U92aSTwoYk7weX/2e67iwDMnjMvPP/Cv8OyyywZyuVsf1plJjwf56dWECBAoBACN9x2V/jcKReEyy84flB/V3j9MiFE/zzu5+j9LkK4EF6ILwWdJEBgTAvMvGLX/ueEV3+LXp357vtpev8MeG25k+uv327wz9EPOuar4abb/1C1njF98fDhLd4XDt9/h8zshfDM6FVMgACB4glEIfz4M78dbvvZrEU67+fog0mEcCG8eN8QekyAwFgT+MAVu1a7VMvffb9FT2H5mm0Hz4R/7aIrwuYbrhOif/S/4657w6eO/kr44Te+ENb4r7dkQi6EZ8KuUgIECBRTIArhhxw7K3xo5nph4sQJYe01VwkzN1wnjOvpqV4TZia8cV4I4UJ4Mb8l9JoAgbEksOXPdqtPcIdKqFSD+KLv1Qnyjq6/+sOL/hx9oOvG2x8aPvahjcO+u26dCbcQngm7SgkQIFBMgT/d91C47pbfhmmLTw2PPfls+NEvbg47b7tJOOaQ3YTwIaeEEN4AqYRyCGV3Ry/mt4ZeEyDQzQJb/Xy3TJp/1YcubVrvPx55Mnxw1yPDuaceGjZYd81M2ieEZ8KuUgIECBCIBH569a3h2C9dFO6+8cLQU+4xEz7gtBDCB4TwSjkEjyjzpUGAAIGuE9jmF7s3rglvXPRdu1lb33L9GvEBF4W3vf4XTUL4K6/OCbseeFJYbOqU8O2vHBV6euI/1rMTB0EI74SifRAgQIDAqARuu/NPYf8jzwx3XffNMHHCBCFcCB/2PPKIslENL4UIECCQucCHr9y91oa+m7L1Nyjh5Z9tfckifY/ujn7IseeEJ556LlxyztFh+rTFMvMRwjOjVzEBAgSKJ/D9K24Mq6z0xrDaym8OL770cjjihPPC+HE94aKzj/Rz9CGng5nwBogQXrzvCj0mQGBsCGx31ccH3A29flf05N+vGBLC//3yq+Hgz58TZs+eG87/0uGZBvDoyArhY+P81gsCBAh0hcBZ5/8oXPiDq/vb+rbVVgpfPnb/8IbllhbChfCm57AQ3hXDWyMJECCwiMBHrvp49Zfn1Zuv9v0CPY3ly7f8Tn9bXp09N3xs/+PDgoULw9nHHxgWmzq5uq5cLofllpmRyVETwjNhVykBAgSKKzBn7rzw9LMvhMWnThn0L9Hujj74nDAT3vAQwov7faHnBAh0t8AOV+9RnQmvJ/HoeeBpLP94QAh/8unnQ3Q39KGv6Hnhwz0yNQ1xITwNZXUQIECAwIgCQrgQ3uwkEcJHHD42IECAQC4Fdrx6j0zaddkHv51Jva1WKoS3KmU7AgQIEEhUoPoP5bOviF/HhKnxy0Qloruxx331Lohborr9q2Fu7HITypNil4kK9Ibe2OWi57aO5rWgd37sYhN6aj8DjPOqVMqhp7RR7Wa6XgQIECDQNQI7XfOJ2vO/+2bAh39OeOfX//ADQnjXnCQaSoAAAQLZCQjhg+2F8IaHEJ7duFQzAQIE2hHY+dpPDPpn3gGXhtcvEU9k/fe2uLidZide1kx44sQqIECAAIFWBIRwIbzZeSKEtzKCbEOAAIH8Cex23Z6Nu6NHM+Khdk14dWY8weXvCuH5Oxm0iAABAgTyJyCEC+FCeP7GpRYRIECgHYHdr9+zVjzh54IP3f8lm1/UTrMTL2smPHFiFRAgQIBAKwJCuBAuhLcyUmxDgACB7hHY43/2qj2frP5cspTevy2Ed89JoqUECBAgkJ2AEC6EC+HZjT81EyBAIAmBPaMQ3vd88DTfL9r0wiS607F9mgnvGKUdESBAgEA7AkK4EC6EtzOClCVAgED+BPa+ce++a8DrE+L1a8KTXb5QCM/fyaBFBAgQIJA/ASFcCBfC8zcutYgAAQLtCOxz4959xftuyta/s2SXL9jkW+00O/GyZsITJ1YBAQIECLQiIIQL4UJ4KyPFNgQIEOgegf1uqoXwZr9Ir/ek0+vP31gI756zREsJECBAIDMBIVwIF8IzG34qJkCAQCIC+9+896DngA+tZOhN0zu1/hsbCeGJHFA7JUCAAIGxJSCEC+FC+Nga03pDgACBT92yT/Wa8Prd0avPB09h+Vwh3MlHgAABAgRGFhDChXAhfORxYgsCBAh0k8CBt0Q/Ry+FSqhdA15/YHjSy1/b8IJcM7kmPNeHR+MIECBQHAEhXAgXwosz3vWUAIFiCBz8q9pMeH0GPK33WRv6OXoxzjC9JECAAIG2BIRwIVwIb2sIKUyAAIHcCRzyq30ad2Wrt64+IZ7g8lffbyY8dyeDBhEgQIBA/gSqIXzeVfEbNnGx+GVCCL2VhbHLlaM7yIzi9dKCF2OXmtAzKXaZqEBvpTd2uXKpHLtMVGB+79zY5Sb1TI1dplIph3HlTauXFHoRIECAQPcIHHrrPqF+87Xqe9814c3uht6p9V8RwrvnJNFSAgQIEMhOQAgfbC+ENzyE8OzGpZoJECDQjsBht+0zfPGkboveV9tZ7zMT3s5xU5YAAQIECiIghAvhzU51IbwgXwK6SYDAmBP4zK/3zeSa8DOF8DF3LukQAQIECCQgIIQL4UJ4AgPLLgkQIJChwBG/jmbCm/74vP9u6fW7pnfq/cvrfzPDXo9ctbujj2xkCwIECBBIQUAIF8KF8BQGmioIECCQosCRt2czE/6l9f0cPcXDrCoCBAgQ6FYBIVwIF8K7dfRqNwECBIYXOOr2fRsrUrgrevUucCGE09YzE+6cJECAAAECIwoI4UK4ED7iMLEBAQIEukrg6N/sO/ju6In9AH3wD9lPfa8Q3lUnisYSIECAQDYCQrgQLoRnM/bUSoAAgaQEjvl/A2bCk6pkmP2evK4QniK3qggQIECgWwWEcCFcCO/W0avdBAgQGF7g2Dv2y+Tu6CcJ4U5JAgQIECAwsoAQLoQL4SOPE1sQIECgmwS+cEc0E57+3dFPeM/5uWZyd/RcHx6NI0CAQHEEhHAhXAgvznjXUwIEiiFw3J3ZzIQf/x4/Ry/GGaaXBAgQINCWgBAuhAvhbQ0hhQkQIJA7gePv3K8xEd6sdUPvmj50u1Gs/+K7zYTn7mTQIAIECBDIn4AQLoQL4fkbl1pEgACBdgRO/O1+mdwd/QvvEsLbOW7KEiBAgEBBBKohfO6VsXu7cOLk2GWiAvMWzo5dbtK4xWKXiQos6J0Xu9y48oTYZaICC3vnxy43rjw+dplav0ZRV98zXONU2Fsph1LPpqEUzYZ4ESBAgEDXCJz0v/vV2hp99w/8Dk94+fPrCOFdc5LC//iUAAAgAElEQVRoKAECBAhkJyCED7YXwhseQnh241LNBAgQaEfglN/tn8nd0Y8Rwts5bMoSIECAQFEEhHAhvNm5LoQX5VtAPwkQGGsCp/4umglP/+7on1v7vFxTujt6rg+PxhEgQKA4AkK4EC6EF2e86ykBAsUQOP2ubGbCj1rbz9GLcYbpJQECBAi0JSCEC+FCeFtDSGECBAjkTuBLd+3faNPQu5wnuPzZd5oJz93JoEEECBAgkD8BIVwIF8LzNy61iAABAu0InPH7/TO5O/oRawnh7Rw3ZQkQIECgIAJCuBAuhBdksOsmAQKFETjz9/sPviv60J4PvUt6h9Yf/g4hvDAnmY4SIECAwOgFhHAhXAgf/fhRkgABAnkUOPuPn8zk7uiHCeF5PB20iQABAgTyJiCEC+FCeN5GpfYQIECgPYGv/DG6Jjz9u6N/+u3faK/hCZd2d/SEge2eAAECBFoTEMKFcCG8tbFiKwIECHSLwDl3ZzMTfsjb/Ry9W84R7SRAgACBDAWEcCFcCM9wAKqaAAECCQjMuvuTCex15F0etKaZ8JGVbEGAAAEChRcQwoVwIbzwXwMACBAYYwJf/79PLnp39EoIpVJoftf0Dqw/UAgfY2eS7hAgQIBAIgJCuBAuhCcytOyUAAECmQmc+6e+mfChd0FPePmANcyEZ3bQVUyAAAEC3SMghAvhQnj3jFctJUCAQCsC591zQCZ3R/+kEN7K4bENAQIECBRdoBrC5/0yNkNl9guxy0QFStNfH7tc5fF7Y5ep1rXsqrHLVZ55MHaZal0z3hS7XG+5HLtMVGBhZUHscuMXRtMf8V69lXIojd+8+vNFLwIECBDoHoHz74lmwtO/O/p+q5+bayR3R8/14dE4AgQIFEdACB98rIXwhocQXpzvAT0lQGBsCVzw52xmwvdd3c/Rx9aZpDcECBAgkIiAEC6ENzuxhPBEhpydEiBAIHGBb/35gEYd9Qnx+icJLu/932bCEz+4KiBAgACB7hcQwoVwIbz7x7EeECBAYKDARfce0Pwu6An+UH2v1YRwZyIBAgQIEBhRQAgXwoXwEYeJDQgQINBVAhffe0DtkvD6K+G7otcT/yf+SwjvqhNFYwkQIEAgGwEhXAgXwrMZe2olQIBAUgLfue9T/XdHD9U/9KWmd0vv5Po9hPCkDqn9EiBAgMBYEhDChXAhfCyNaH0hQIBACJfcF10TXrv4uxRKoVKdqq6/Bt81vZPrd1/VTLjzjwABAgQIjCgghAvhQviIw8QGBAgQ6CqB797fmAmvVCqh9Boz4Z1cv5sQ3lXnicYSIECAQEYCQrgQLoRnNPhUS4AAgYQEvnf/p/qfEt6siqE3SR+63WjW77LK1xPqUWd26znhnXG0FwIECBBoU0AIF8KF8DYHkeIECBDImcAP/hrNhFcvBe9/pbG8sxCeszNBcwgQIEAglwJCuBAuhOdyaGoUAQIERi3ww78e2Fe2L4nX745eT+L9l4h3dv3H3vq1Ubc5jYJmwtNQVgcBAgQIjCgghAvhQviIw8QGBAgQ6CqBH/3toOrN2Oo3XUvrfUchvKvOE40lQIAAgYwEhHAhXAjPaPCplgABAgkJRCE8+il6/8R3fcI74fft/3NWQj3qzG7NhHfG0V4IECBAoE2B6h/ohdfH3kvl6Qdil4kKlJZaMXa5yqP3xC4z6rr++ZfR1fXmNeKXm7R4/DLRA2cGXuTX6h5eeLTVLfu36630hPISOw+6pjD2ThQgQIAAgdQFLn/g4OpDyfofRla/O3r1oWUDPq8vd2j99v95Tup9jVOhEB5Hy7YECBAg0LLAgoULQ7lUDuXygLux9JV+6eVXQ7R+iWmN8CeED6atCOFCeMujzYYECBDIp8BPHjhkcNKuN3PYBD6gD22u/8hKX80nSF+rhPBcHx6NI0CAQHcKzJ4zL+y433Fh3123Dltttm5/J16dPSccedL54abb/1D97G2rrRRmnXRwWGrGtNpP1cyE91sJ4Y1z30x4d34PaDUBAgR++vdPV+e4688Hryfy+rXh/ct9M+CdWr+dEO7kI0CAAIEiCZxx3mXh4h9eU+3y6cfsNyiEf+v7vww/vvKWcOmsY8LkSRPCJ486O6y4wnLhxM/uKYQPOUmEcCG8SN8b+kqAwNgUuOLvn64F8PqPzwddHF77DXoS67d9y9m5BjUTnuvDo3EECBDoPoEXXnw5zJk3L+x8wInhsH13GBTCP7rPF8PMDdcJ++yyVbVj193y23DYceeGe26+uHplmJnwxvEWwoXw7hv9WkyAAIHBAj9/6LBQqUR3R++7BnzoNd8JLX9YCHcqEiBAgEARBWbudEQ4aM/tBoXwdT6wfzjpyL2qQTx63fvXh8P2+x4XfnPl18PrFpsqhA84UYRwIbyI3xv6TIDA2BL4xUOH1TpUv8a73r2El7dZ8axhIXt7K9V/FOjpKWcKbSY8U36VEyBAYOwKDA3h0R+91Tf6RDj31EPDBuuuWe343x9+NGyzxzHhhsvODMsus6QQLoQPOyAqoSeUprs7+tj9ttAzAgTGqsCVDx8++Plk9TnxZs8t69D6rYcJ4dH/hxx35rer1Md/5hOZkgvhmfKrnAABAmNXoNlM+MlH7R0232DtasfNhDc//mbCGzZC+Nj9ntAzAgTGtsBVUQhv/Bi92YPJOv75Vm8+YxBsdPnbSV+5NDz3wkvho1ttIISP7dNO7wgQIFBcgeFCeHRN+BYbvSvsvfOWVRjXhAvhrYwQd0dvRck2BAgQyJ/A1f84onZNeP3a7/5rwGs3a1vk8w6t33JICH919tzw75dfCWd/88dh0sQJQnj+ThUtIkCAAIF2BKLnf1d6K2Gr3T8X9t99m7DVpuuG8ePHVXd5wfeuCpdf9avq3dGnTJ4Y9j/yLHdHb4JtJrwBI4S3MyKVJUCAQHYC1/zjiGrli1wCXr0reqNdnV7/gTd9edhOn3D2JWHhwoVCeHanhJoJECBAIAmB6G7n0Qz3wNdVl5xaDduvvDonfOaEb4Rb77i7unr1VVYMs04+JCyz1HSPKBtyMIRwITyJ8WmfBAgQSFPg2n9+tvb3vRRdGl6f+U5++QNv+pIQnuaBVhcBAgQI5F/gxZdeCfPnLwhLzZjW39jqH+mF18dufOXpB2KXiQqUlloxdrnKo/fELjPquv75l9HV9eY14pebtHj8MtHMxsBpjFb38MKjrW7Zv52Z8NhkChAgQCAXAtf987N914Q3a87QOfCh241u/cwVThfCc3EGaAQBAgQI5FpACB98eMyENzyE8FwPXY0jQIBAU4H/+ddR1RnwvqnwpteAd3r95kK4s5IAAQIECIwsIIQL4c3OEiF85PFjCwIECORRIArh9Vd0CXg0r53G8mZvPG0Qx8KFvaG3tzec9NVLw4IFC8Nxh+8Renp6Qrk84ML0FAE9oixFbFURIECAQHOBagh/6bLYRJXn/xW7TFSg9MZ3xC5XefT/Ypep1rXkKH76/th9o6orLPn62OVKkxqXBcQqPH5SrM2jjSsvPha7TG/oCeUZuw26iU/snShAgAABAqkL3PjI5wZcE94/IV6f+E7sfdM3njqorz/6xc3h+LO+M+izEz+7Z9jug+9P3aT6/wWV6u8DvAgQIECAQLYCQvhg/4oQ3g8ihGc7NtVOgACB0Qrc9MjRoy3aVrmN33BKW+WTLiyEJy1s/wQIECDQkoAQLoQ3O1GE8JaGkI0IECCQO4GbHz0mui36IteEN5sCrz83vN31GwnhuTsXNIgAAQIEcigghAvhQngOB6YmESBAoA2BW6IQ3vcqhVKovMZV4Z1cv+HrT26j1ckXNROevLEaCBAgQKAFASFcCBfCWxgoNiFAgEAXCdz62Of7JsJLfc8Jr0+MJ7u8wetPyrWSEJ7rw6NxBAgQKI6AEC6EC+HFGe96SoBAMQRufezY8Fr3Hx/dU8Abds3Kv2/5E3MNLITn+vBoHAECBIojIIQL4UJ4cca7nhIgUAyBXz/+hb4Z8FL/teHRfcGja7/r14onsSyEF+P80ksCBAgQaFNACBfChfA2B5HiBAgQyJnA7Y9/YUCL6k8KH/pe36Rz69db7vicSQxujpnwXB8ejSNAgEBxBIRwIVwIL85411MCBIoh8P+eOK5/Jrw+453G+3uF8GKcYHpJgAABAu0JCOFCuBDe3hhSmgABAnkTiEJ4s/ntJD9/z7LH5Y1iUHvMhOf68GgcAQIEiiMghAvhQnhxxrueEiBQDIE7nzx+wEx4/XHhtWvCG48P7/yyEF6M80svCRAgQKBNASFcCBfC2xxEihMgQCBnAr998oS+Fg29j3myy+/6j4HXoucMJYRgJjx/x0SLCBAgUEgBIVwIF8ILOfR1mgCBMSzwv0+dWL0Lem3me9H30HeX9E6vX0cIH8Nnla4RIECAQMcEohAe/nVm7P1V7nswdpmoQHn9TWOXq9x3V+wy1QKvXyF+uUf/Gb9MVGLZ5eKXGz8pfpnoX/InTo1drvL8o7HL9IZxobzCIdX/V/MiQIAAge4R+N1TJ/ZfE96s1fVrwzu5fu1ljs01kpnwXB8ejSNAgEBxBITwIcdaCO8HEcKL8z2gpwQIjC2B3z99UibXhL9TCB9bJ5LeECBAgEAyAkK4EN7szBLCkxlz9kqAAIGkBf7w9MlJVzHs/t+x9DGZ1NtqpWbCW5WyHQECBAgkKiCEC+FCeKJDzM4JECCQusAfnzmlek14/drvtN7fLoSnfqxVSIAAAQJdKCCEC+FCeBcOXE0mQIDAawjcHYXwDF5rLnV0BrW2XqWZ8NatbEmAAAECCQoI4UK4EJ7gALNrAgQIZCDwp2dP67smvD4hXr9LerLLb1vqcxn0tvUqhfDWrWxJgAABAgkKCOFCuBCe4ACzawIECGQgcM+zp1VrTfap4Ivuf/Ulj8qgt61XKYS3bmVLAgQIEEhQQAgXwoXwBAeYXRMgQCADgT8/d/qwzwdv9lzwTn0uhGdwsFVJgAABAt0nIIQL4UJ4941bLSZAgMBrCdz73Okh9D8pvP5E8KFPBh/6efvrV5vx2VwfGDPhuT48GkeAAIHiCAjhQrgQXpzxrqcECBRD4L7nv1ydCa/m8GocH3BN+IDlTq//LyG8GCeYXhIgQIBAewJCuBAuhLc3hpQmQIBA3gSiEF5/lUq1m7GlsbzqEkfkjWJQe8yE5/rwaBwBAgSKIyCEC+FCeHHGu54SIFAMgb++cMai14SHyoAZ8frM+ID3DqxfZboQXowzTC8JECBAoC0BIVwIF8LbGkIKEyBAIHcCf33hzPovzattS+su6W+dfnjuLAY2yEx4rg+PxhEgQKA4AkK4EC6EF2e86ykBAsUQeODFszN5Tvhbpx+Wa2AhPNeHR+MIECBQHIFqCH/h0tgdrtzxm9hlogKlVd8Su1zl4Udil6nWNWN67HKVf78cu0y1rhWWi1+uVI5fJioxJX6/wrOPx66rN4wL5ZWPDNH1hF4ECBAg0D0CUQivv6o3ZavOhddeSS7/57RDc40khOf68GgcAQIEiiMghA8+1kJ4w0MIL873gJ4SIDC2BB7891czeU74StM+nWtIITzXh0fjCBAgUBwBIVwIb3a2C+HF+R7QUwIExpbAg/8+J5MOveV1B2dSb6uVCuGtStmOAAECBBIVEMKFcCE80SFm5wQIEEhd4OGXvlZ7Tnjfa9HHlNXuit7p9Su+7qDU+xqnQiE8jpZtCRAgQCAxASFcCBfCExtedkyAAIFMBKIQXn2ldVv0vl6+efEDM+lvq5UK4a1K2Y4AAQIEEhUQwoVwITzRIWbnBAgQSF3gHy+dOyCB15N48u9vWvxTqfc1ToVCeBwt2xIgQIBAYgJCuBAuhCc2vOyYAAECmQj886VvZFLvCot/MpN6W61UCG9VynYECBAgkKiAEC6EC+GJDjE7J0CAQOoC/3r5vBD9fa9fC157r4RSKboWfOjn9eX21wvhqR9qFRIgQIBANwoI4UK4EN6NI1ebCRAg0FzgkZfPr65M+ZLw8IbF9sv1YTETnuvDo3EECBAojoAQLoQL4cUZ73pKgEAxBB595YJMnhP+hsX2zTWwEJ7rw6NxBAgQKI6AEC6EC+HFGe96SoBAMQSiEF4Kpf6Z8EVvyVZJZP3yU/fONbAQnuvDo3EECBAojoAQLoQL4cUZ73pKgEAxBB5/9cLaTHg9iNevCU94WQgvxvmllwQIECDQpoAQLoQL4W0OIsUJECCQM4HHX72o1qKULwpfbsqeOZMY3Bwz4bk+PBpHgACB4ghUQ/i9J8TucO+fH4xdJipQWnp67HK9/3g6dpmoQM87V45drvLcC7HLVPv1+v+IXy66Xe1oXhMnxS81b07sMr1hXCiveHj17rpeBAgQINA9Ak+8+u1qAq/NhDd+jJ708rJTPpFrJCE814dH4wgQIFAcASF88LEWwhseQnhxvgf0lACBsSXwZDWER/+CuujV4El+/h9TPp5rSCE814dH4wgQIFAcASFcCG92tgvhxfke0FMCBMaWwFOzL+m/O3o9h9efE57kshA+ts4jvSFAgACBhASEcCFcCE9ocNktAQIEMhJ4evalmdS89OTdMqm31UrNhLcqZTsCBAgQSFRACBfChfBEh5idEyBAIHWBZ+Z8L5PnhC89edfU+xqnQiE8jpZtCRAgQCAxASFcCBfCExtedkyAAIFMBKIQHt2Erdk14dHN2pJYv+SknTPpb6uVCuGtStmOAAECBBIVEMKFcCE80SFm5wQIEEhd4Lm5P8hkJlwIT/1Qq5AAAQIEulFACBfChfBuHLnaTIAAgeYCz839YW1lJVQfMxndIz2N5RkTP5brw2ImPNeHR+MIECBQHAEhXAgXwosz3vWUAIFiCLww90fV54PXnwue1vsSE3fMNbAQnuvDo3EECBAojoAQLoQL4cUZ73pKgEAxBKIQXpsCH/Cc8BSWp0/YPtfAQniuD4/GESBAoDgCQrgQLoQXZ7zrKQECxRD497zLq9eE14N4qVRKZXnaRCG8GGeYXhIgQIBAWwJCuBAuhLc1hBQmQIBA7gT+Pe8nmbTpdRM+kkm9rVZqJrxVKdsRIECAQKICQrgQLoQnOsTsnAABAqkLvDT/p31PJ+v7SXr/08qSXV58wnap9zVOhUJ4HC3bEiBAgEBiAkK4EC6EJza87JgAAQKZCLw8/4oQ+p8T3qwJ9WTeufWLjd82k/62WqkQ3qqU7QgQIEAgUYFqCP/d0bHrqMyfH7tMVKC0xOtil6s8+lTsMlGB8vqbxS5XefrB2GWq/Vp6pfjlesbFLxOVqB60mK8F82IWCKG30hNKU7auXlLoRYAAAQLdI/DKgp9n8pzwxcZ/ONdIQniuD4/GESBAoHsFFixcGMqlciiXW0tOQvjgYy2ENzyE8O79HtByAgSKLfDqgl9UAer3ZqtrJL08Zdw2uYYXwnN9eDSOAAEC3Skwe868sON+x4V9d906bLXZuv2duPG234eDjz1nkU79/voLwoTx482ED5ARwoXw7hz9Wk2AAIGGwOwFV4YBDyfr/2F6/6XhUUAf8IP1Tn0+ZdzWuT4MQniuD4/GESBAoPsEzjjvsnDxD6+pNvz0Y/YbFMJvuO2u8LlTLgiXX3D8oI6t8Pplan+C/Ry930UIF8K7b/RrMQECBAYLzF5wVf9jwlO6J1u1vkk9W+X6UAjhuT48GkeAAIHuE3jhxZfDnHnzws4HnBgO23eHRUL48Wd+O9z2s1mLdMzP0QeTCOFCePeNfi0mQIDAYIG5C69uXBMeKqEUas8Jrz8vfNB7B9dPGrdlrg+FEJ7rw6NxBAgQ6F6BmTsdEQ7ac7tFQvghx84KH5q5Xpg4cUJYe81VwswN1wnjenpq9/gyE24mfJhT3jXh3fs9oOUECBRbYO7C2i/j0n5N7PlA2lXGqk8Ij8VlYwIECBBoVWC4EP6n+x4K193y2zBt8anhsSefDT/6xc1h5203CcccspsQPgTWTHgDpBJ6Qpjs7uitjj3bESBAIC8C83qvrV70Hf1EvH4ztoHv9YvEO71+Qs8WeSEYth1CeK4Pj8YRIECgewWGC+FDe/PTq28Nx37ponD3jReGnnKPmfABQEL4gBBe6QnBI8q698tAywkQKKzA/N7rMun7+PLMYet95rkXw5TJk8KUyRMzaVe9UiE8U36VEyBAYOwKtBLCb7vzT2H/I88Md133zTBxwgQhXAgfdkD4OfrY/Z7QMwIExrbAgsr/9F8DXp8Kr18TnuTy+PLmg2D/+eiTYf8jzwr/eOTJ6ufbffD94QuHfTyMH9eTyQEQwjNhVykBAgTGrkD0fPBKbyVstfvnwv67bxO22nTdMH78uGqHv3/FjWGVld4YVlv5zeHFl14OR5xwXvUP4EVnH+nn6ENOCTPhDRAhfOx+X+gZAQJjW2Bh5YZaB5N+MPiQ/feUNh0Eu+8RZ4TFpk4OJx+1T3jiqWfDDvsdH75w6O5h683fm8kBEMIzYVcpAQIExq7AYcedW73ue+DrqktODSuusFw46/wfhQt/cHX/qrettlL48rH7hzcst7QQLoQ3HRRC+Nj9vtAzAgTGtkBv5cZEngM+0vPEe0qb9MO++NIr4b1bfyp892vHhHes/tbq5yd/9dLwxFPPhVknH5LJARDCM2FXKQECBIorMGfuvPD0sy+ExadOCdOnLdYP4e7og88JM+ENDyG8uN8Xek6AQHcLVCo3hfrN16L3/gnr6IkowyTpTq0vhY374f7+8KNhmz2OCbf85Cth6SWnVz+/9PLrw8+vuz1cfsHxmQAL4Zmwq5QAAQIEhgoI4UJ4s1EhhPu+IECAQLcK3NL8OeFDnwve0eWN+sH+cM/fwq4Hnhx+c+XXq09niV4/uvKWcN4lPw83/fjsTGCF8EzYVUqAAAECw4XwVw/dLDZMaeLobqpSnjo+dl0Ln5kdu0xUYPLWq8YvN2du/DLRxMLbVolfrqd2zX7sVzl+ucof74ldTW95QuiZeU71ETdeBAgQINBNAjfXGlud+a5PfaewHBohvD4T/quffjUsNWNatTlmwrvpHNJWAgQIEEhMIJoJF8IH8Arh/RhCeGLDzo4JECCQrED0c/Tqq9lvz+vVd3h9qfFz9OGuCT/x7EvCU88875rwZI++vRMgQIBA3gWE8CFHSAgXwvM+aLWPAAECIwn03jjSFsmsLzduzBZVsPdnvhxet9jUcPJRe7s7ejLi9kqAAAEC3SgghAvhzc5bM+HdOKK1mQABAiGE3hsyeU54qWfw5W0P/fPx6nPCH3n86eph+fAW64fjDt+j/xGqaR8r14SnLa4+AgQIEBhWQAgXwoVwXw4ECBAYYwILr691KO1rwns2Hxbyyaefrz4vfOqUSZlCC+GZ8qucAAECBOoCQrgQLoT7PiBAgMAYE1gQhfDa88gqfXc/T2V53MxcQwrhuT48GkeAAIHiCAjhQrgQXpzxrqcECBREYP612XR0/BbZ1NtirUJ4i1A2I0CAAIFkBYRwIVwIT3aM2TsBAgRSF5h/zYBrwms3Sa9UKqEUPa4s+sNfKiWzfsIHU+9qnAqF8DhatiVAgACBxASEcCFcCE9seNkxAQIEshGY98shjyerN6P2E/X6T9Mb7x1aL4Rnc7zVSoAAAQLdJSCEC+FCeHeNWa0lQIDAiAJzf9l/LXj9mvBU3iduNWLTstzATHiW+uomQIAAgX4BIVwIF8J9IRAgQGCMCcy5MpsOTdo6m3pbrFUIbxHKZgQIECCQrIAQLoQL4cmOMXsnQIBA6gJzftF/zXffJeDpLE/+UOpdjVOhEB5Hy7YECBAgkJiAEC6EC+GJDS87JkCAQDYCs39erbfxeLJaM5JeDkJ4NsdbrQQIECDQXQJCuBAuhHfXmNVaAgQIjCjw6s+yuSZ8yrYjNi3LDcyEZ6mvbgIECBDoF4hC+L/32zC2yNR3Lx+7TFSg9+V5scv1vjw/dpmowMSt3xG7XOX5F2OXiQqU/nuN2OVKiy0du0y1wPhJsctV7r09dpne0vhQ/u9joifZeBEgQIBANwm88tNBra3eE71+U/Rh+tGx9VO2y7WSEJ7rw6NxBAgQKI6AED74WAvhDQ8hvDjfA3pKgMAYE3jlJ+lcA1593ngt4FefQ77YR3MNKYTn+vBoHAECBIojIIQL4c3OdiG8ON8DekqAwBgTePnyaoeSvgZ86P6DED7GTiTdIUCAAIFEBIRwIVwIT2Ro2SkBAgSyE3jpx7UAXp2pHuY9lJJZv/gO2fW5hZrNhLeAZBMCBAgQSF5ACBfChfDkx5kaCBAgkKZA5d+X9f1EvP5T8QHv1RnyYT6v/qQ8hPql47WfmMcrHxbfMc1uxq5LCI9NpgABAgQIJCEghAvhQngSI8s+CRAgkKHAv384zDXhQwN1fYa8WSAfxfppH8uw0yNXLYSPbGQLAgQIEEhBQAgXwoXwFAaaKggQIJCiQOXFHzRmtOsz3ym8h2k7pdjL+FUJ4fHNlCBAgACBBASEcCFcCE9gYNklAQIEshR48fvDXwve7BrxTn0+fZcsez1i3UL4iEQ2IECAAIE0BIRwIVwIT2OkqYMAAQLpCVSe/27za8KbXevdgc/D9F3T6+QoahLCR4GmCAECBAh0XkAIF8KF8M6PK3skQIBApgLPXzrkpmr1u6Q3udla/0x4m+tn7JZpt0eqXAgfSch6AgQIEEhFQAgXwoXwVIaaSggQIJCaQOW5S/rrqt/tvP5BksulGbun1sfRVCSEj0ZNGQIECBDouIAQLoQL4R0fVnZIgACBbAWe+04214QvuUe2/R6hdiE814dH4wgQIFAcASFcCBfCizPe9ZQAgWIIVJ65OJT6fmJev016/bnfjeXaT9Q7uT4s+YlcAwvhuT48GkeAAIHiCER/f1/Ya4PYHZ625Vtil4kKLHx+TvxyvZX4ZUII4z68afxyTz0av0wIofSWNeOXmzg1fpnoETM94/k7CmoAACAASURBVOKXe/ze2GV6w7hQXna/6s19vAgQIECgiwSeubhvJjyE6C9oKQy4JjzJ5aX3zDWSEJ7rw6NxBAgQKI6AED7kWAvh/SBCeHG+B/SUAIGxJVB5+sL+DiV5DXhUycD9l5beK9eQQniuD4/GESBAoDgCQrgQ3uxsF8KL8z2gpwQIjDGBp7+VzTXhy+yTa0ghPNeHR+MIECBQHAEhXAgXwosz3vWUAIFiCFSe/GYY9kHhfT9OH/L8ssZzydpcXxLCi3GC6SUBAgQItCcghAvhQnh7Y0hpAgQI5E7gyW9mc034svvljmJgg8yE5/rwaBwBAgSKIyCEC+FCeHHGu54SIFAMgcoT52XS0dKy+2dSb6uVCuGtStmOAAECBBIVEMKFcCE80SFm5wQIEEhf4IlvZHNN+HIHpN/XGDUK4TGwbEqAAAECyQkI4UK4EJ7c+LJnAgQIZCFQeezrtWvC69d4D32vPh+88+tLQngWh1udBAgQINBtAkK4EC6Ed9uo1V4CBAiMIPDY16sz4fWgXX9OeNLLpdcfmOtDYyY814dH4wgQIFAcASFcCBfCizPe9ZQAgWIIVB6dlUlHS68/KJN6W61UCG9VynYECBAgkKiAEC6EC+GJDjE7J0CAQOoClUfPqT52rFQqNWbE01h+wyGp9zVOhUJ4HC3bEiBAgEBiAkK4EC6EJza87JgAAQKZCFQe+UoI4TWu+W52rXibn5eE8EyOt0oJECBAoMsEhHAhXAjvskGruQQIEBhJ4F9fCZUBgXrYa8ITWF9a4dCRWpbpejPhmfKrnAABAgTqAkK4EC6E+z4gQIDA2BKo/POsTDpUWuGwTOpttVIhvFUp2xEgQIBAogJRCH/wfWvErmP5DVeIXSYqUJmzIHa5ytyFsctEBaYcvV3scpX7/xq7TFSgvPb68ctNmBq/TFRi3ITY5SoP/S52md4wLpTfcnjtZrpeBAgQINA1ApV/njng6WR9d0mv3y29/73+i/XOrS+96TO5NhLCc314NI4AAQLFERDCBx9rIbzhIYQX53tATwkQGFsClYfPqF0S3uxV6QvgHV4vhI+t80hvCBAgQCAhASFcCG92agnhCQ06uyVAgEDCApWHv1y9K3p0d/ToLunVnzQNeU9ifWnFzybcs/Z2bya8PT+lCRAgQKBDAkK4EC6Ed2gw2Q0BAgRyIlB58Et9LRk65V0P5PWGdnZ96S1CeE5OAc0gQIAAgTwLCOFCuBCe5xGqbQQIEIgvUPn76dFdWBZ9TFl9RrzZ48vaXF9a6aj4jU2xhJnwFLFVRYAAAQLNBYRwIVwI9w1BgACBsSVQeeC0TDpU+k8hPBN4lRIgQIBAdwkI4UK4EN5dY1ZrCRAgMJJA5W+nLnJN+NBrwJNYLq989EhNy3S9mfBM+VVOgAABAnUBIVwIF8J9HxAgQGBsCVTuP6V2d/RFLvkecE14AutLQvjYOpH0hgABAgSSERDChXAhPJmxZa8ECBDISqBy/8n9d0Ovz3gPfa/fLb2T68urfj6rLrdUr5nwlphsRIAAAQJJCwjhQrgQnvQos38CBAikK1D5y0npVthXW+m/hPBM4FVKgAABAt0lIIQL4UJ4d41ZrSVAgMBIApV7TwyVUAmlUFrkvf4b9STWl1f7wkhNy3S9mfBM+VVOgAABAnUBIVwIF8J9HxAgQGBsCVT+fEImHSr9txCeCbxKCRAgQKC7BIRwIVwI764xq7UECBAYSaByz/H9d0dvds13Ep+X1zhupKZlut5MeKb8KidAgACBgTPhPyivEhtk1ZWj26rGfy02rRy7UGVhdHvX+K+3fuUDsQvN+fmfY5eJCkzaerVRlRtNodLSM2IXq9z/UOwyveUJoWeb80JpdIc6dn0KECBAgEBnBCr/d9zgu6PX75Ke8HtJCO/MAbQXAgQIEOgegRdfeiXMnTs/LLPU9GEb/dLLr4YFCxeGJaYt3r8+mgkXwhtcQnjDQgjvnrGvpQQIEBgoUPm/Lw6YCQ/Vf0ytznzXrxEvlRJZX14zm5/Bt3r0zYS3KmU7AgQIEBhR4JnnXgy7H3xK+McjT1a3XelNy4d9dtkqbL35e6vLr86eE4486fxw0+1/qC6/bbWVwqyTDg5LzZhWfUKJEC6ED3eSCeEjDj0bECBAIJcClT/Wrs1e5DHhoTZBXn91en3p7UJ4Lk8IjSJAgACBzgs89cwL4WfX3ha2mblemDp5Urj08uvDxZddG2694pwwedKE8K3v/zL8+MpbwqWzjqkuf/Kos8OKKywXTvzsnkL4kMNhJrwBIoR3fqzaIwECBNIQqPzh2MZd0aMZ8Gjmu3639ASXy+/I5tForZqaCW9VynYECBAgEFvgkcefDjN3OiJcOuvosNYaK4eP7vPFMHPDdaqz49Hrult+Gw477txwz80XV/9N3Ex4g1gIF8JjDzgFCBAgkDOB3t9/ftgZ76GXhNeb3exS8bjrS2sJ4Tk7FTSHAAECBNISuOKa28LnT78w3PazWWHG9MXDOh/YP5x05F7VIB697v3rw2H7fY8Lv7ny6+F1i00VwgccGCFcCE9rnKqHAAECSQlU7jrmNe6OPuAa8UHXhvfNmFdGv7689ilJdakj+zUT3hFGOyFAgACBoQJ/e+iRsPMBJ4WPbz8zHLjnttU/wqtv9Ilw7qmHhg3WXbO6+d8ffjRss8cx4YbLzgzLLrOkEC6EDzuQKuUJoezu6L5kCBAg0HUClf89utrm6gx3dBF430NGkl4urSOEd93JosEECBAg0J7Ao088E3Y76OSwzttXDacctU/o6ak9DiyaCT/5qL3D5husXV02E97c2Ux4w6bSMyGUt/aIsvZGpdIECBBIX6Dy28/VrgGvz3QPvSt6Qsvld52Wfmdj1GgmPAaWTQkQIEBgZIEHHno0fOLQ08LG668Vjj109zCup6e/UHRN+BYbvSvsvfOW1c9cEy6Ej3xGheDGbK0o2YYAAQL5E+i986jqNeEJPxZ8kf2X3i2E5+9s0CICBAgQSETg/r//K2y317Fhy03eEw7aa7tQLtdmwKdMnlh9JvgF37sqXH7Vr6p3R48+2//Is9wdvcmRMBPegBHCExmudkqAAIHEBSp3HNm4JrzvsWTV54QPdw14B9eX1/1S4n1rpwIz4e3oKUuAAAECgwSuuenO8JkTvrGISvSc8NOO3je88uqc6vpb77i7us3qq6wYZp18SFhmqekeUTZETQgXwn29ECBAoNsFev/fZ2sz4fWbrNU7NGA5ifVCeLefOdpPgAABAh0XePGlV8L8+QvCUjOm9e87+gPtEWUNaiFcCO/4wLNDAgQIpCxQ+c0Rr3F39CYz4s1mymN8Xl7vjLZ6umDhwlAulUO5HP0TQedfZsI7b2qPBAgQIDAKASF8MJoQLoSPYhgpQoAAgVwJ9P76M02vCa83tNk14+2sL60/+hA+e868sON+x4V9d906bLXZuol4CuGJsNopAQIECMQVEMKF8GbnjGvC444m2xMgQCAfApVfH16bCa/eBT30BfIBy6Xop+qdX19+31mjAjjjvMvCxT+8plr29GP2E8JHpagQAQIECHSNQBTCb15uldjtfdumS8cuExXoGV+7aVyc18J5C+Ns3r/tkl/6WOxylTt+H7tMVKC82Raxy1VefT52mahAafFlYperPPKX2GV6w7hQXvnI2jNmvQgQIECgawR6bz2sv60DHhNe/SzJ5fL7RxfCX3jx5TBn3ryw8wEnhsP23UEI75ozTUMJECBAYFQCQvhgNiG84SGEj2pIKUSAAIHMBSq/OjSba8I3/EpbfZ+50xHhoD23E8LbUlSYAAECBHIvIIQL4c1OUiE898NXAwkQIDCsQO/Nn25Meaf4wPDykBB+5fW/CU88/dywbVxt5TeH9dZZfdA6IdwJTYAAAQKFEBDChXAhvBBDXScJECiQQOXmQwbMhIfqZUWN54Qnt1ze+JxByt/76Q3hkcefHlZ+rTXeGjZ7/9pCeIHOS10lQIAAgT4BIVwIF8J9HRAgQGBsCfTeeHB/h4ZeAz60p51cX95kcAiPq2omPK6Y7QkQIECgKwWEcCFcCO/KoavRBAgQaCpQueGgYe6K3nc39Ppzvxe5a3r768ubfm1URyV6PniltxK22v1zYf/dtwlbbbpuGD9+3Kj29VqFPKKs46R2SIAAAQKjERDChXAhfDQjRxkCBAjkV6D3fw7MpHHlzUYXwg877txw3S2/HdTmqy45Nay4wnId7YcQ3lFOOyNAgACB0QoI4UK4ED7a0aMcAQIE8ilQuf5T1WvAaxeDN64BT3q5PPPcfIL0tUoIz/Xh0TgCBAgUR0AIF8KF8OKMdz0lQKAYAr3XHtDoaJIPBo9qGbD/8hZCeDHOML0kQIAAgbYEhHAhXAhvawgpTIAAgdwJVK79ZOifCB9mRrxUKiWyvvyBb+TOYmCDzITn+vBoHAECBIojIIQL4UJ4cca7nhIgUAyB3qv3z6Sj5Q+el0m9rVYqhLcqZTsCBAgQSFRACBfChfBEh5idEyBAIHWByi/3a1wTXv/FeH1GPMHl8lbfTL2vcSoUwuNo2ZYAAQIEEhMQwoVwITyx4WXHBAgQyESg96p9a/VW+hJ3vRUJLwvhmRxulRIgQIBAtwlEIfwH5VW6rdkttffDh72ppe0GbvSPG/8Zu0xUYOWj3xO73Lx7n4ldJiow7g2Lxy437/+ejl2mMn5imHrGL6s30/UiQIAAge4R6L1yn0YArwfv/vfGXdP7b6pWv7la9X3068vbXJBrJDPhuT48GkeAAIHiCAjhg4+1EN7wEMKL8z2gpwQIjC2B3p/vnUmHyh/6Vib1tlqpEN6qlO0IECBAIFEBIVwIb3aCCeGJDj07J0CAQGICvT/fqzajXZ3q7r8IPPHl8ocvSqxPndixEN4JRfsgQIAAgbYFhHAhXAhvexjZAQECBHIl0HvFnpm0p7ytEJ4JvEoJECBAoLsEhHAhXAjvrjGrtQQIEBhJoPene1bvjl57Hnh67z0fuXikpmW63kx4pvwqJ0CAAIG6gBAuhAvhvg8IECAwtgQWXr5HKIVSqIRKqu/ljwrhY+tM0hsCBAgQSERACBfChfBEhpadEiBAIDOB3h/vMWAGPFSfclGdEa8H80Ez5J1b37PDdzLrcysVmwlvRck2BAgQIJC4gBAuhAvhiQ8zFRAgQCBVgYWXfbxWX8LPBR+6/54dhfBUD7TKCBAgQKA7BYRwIVwI786xq9UECBBoJrDwB1EIrz/ve/B7fUY8ifU9O12S64NiJjzXh0fjCBAgUBwBIVwIF8KLM971lACBYggs/N5utd+Y11/1GfH+975g3uH1PTsL4cU4w/SSAAECBNoSEMKFcCG8rSGkMAECBHInEIXwxjXgQ6/5Tm553K7fzZ3FwAaZCc/14dE4AgQIFEdACBfChfDijHc9JUCgGAILLt211tFFZsBDCAMmyDu9ftxuQngxzjC9JECAAIG2BIRwIVwIb2sIKUyAAIHcCSz4ThTCmyXw5D4f9/Hv5c5iYIPMhOf68GgcAQIEiiMghAvhQnhxxrueEiBQDIEFF+9Sm/FOLm8Pu/9xewjhxTjD9JIAAQIE2hJIO4TPWCJ+c597Pn6ZqMT233pn7IJz7noidpmowGLHfSx2ucr998UuUysw8LeEre1i4f2PtbbhgK0qPRPC+D2+M+jePrF3ogABAgQIpC6w4KJd+p4TXs/hpVSWx+/1/dT7GqdCM+FxtGxLgAABAokJCOGDaYXwhocQntiws2MCBAgkKjD/Wzv1779UqgXw+ivJ5fF7/yDRfrW7cyG8XUHlCRAgQKAjAkK4EN7sRBLCOzLE7IQAAQKpCyy4YKdQCZVQCvUZ8GHeE1g/ft8fpt7XOBUK4XG0bEuAAAECiQkI4UK4EJ7Y8LJjAgQIZCIw//z4l0h1oqHj9xPCO+FoHwQIECAwxgWEcCFcCB/jg1z3CBAonMD88z7Wdw34ojPgIfrD3/cT9fpP0we+t7N+wicvy7W1mfBcHx6NI0CAQHEEhHAhXAgvznjXUwIEiiEw/9wdqx2t/yS93uukl8cfIIQX4wzTSwIECBBoS0AIF8KF8LaGkMIECBDIncD8r+8wzEx4dQK86Qx53wR5W+snHPij3FkMbJCZ8FwfHo0jQIBAcQSEcCFcCC/OeNdTAgSKITBv1vaZdHTCQT/OpN5WKxXCW5WyHQECBAgkKiCEC+FCeKJDzM4JECCQusC8c7bvn9Eeeo13kssTD7k89b7GqVAIj6NlWwIECBBITEAIF8KF8MSGlx0TIEAgE4F5X/nosPUOvSZ86Ebtrp/waSE8kwOuUgIECBDoLgEhXAgXwrtrzGotAQIERhKYd/ZH6hPeqb5PPOwnIzUt0/VmwjPlVzkBAgQI1AWEcCFcCPd9QIAAgbElMPfM7TLp0MTDf5pJva1WKoS3KmU7AgQIEEhUQAgXwoXwRIeYnRMgQCB1gXlnbFe9Jrzvduih/hzwpJcnHnFF6n2NU6EQHkfLtgQIECCQmEDaITyxjgyz46WWjF/bM8/GLxOV+OBey8Yu+NdbnoxdJirQ2xu/2HPPVWIXKk+eFGY+dnf1/9m8CBAgQKB7BOZ+adtMGjvxs0J4JvAqJUCAAIHuEhDCBx8vIbzhIYR311jWWgIECNQF5p6+7ZDnfUfPB48mxktNngPemfWTjvpZrg+CmfBcHx6NI0CAQHEEhHAhvNnZLoQX53tATwkQGFsCc079UCiFUqjf7Tyt94mfE8LH1pmkNwQIECCQiIAQLoQL4YkMLTslQIBAZgJzT/nQsDPeQ68JHzoz3u76Scf8IrM+t1KxmfBWlGxDgAABAokLCOFCuBCe+DBTAQECBFIVmHPSNsPXF90e5LXu89Hm+kmfF8JTPdAqI0CAAIHuFBDChXAhvDvHrlYTIECgmcCcE7ap/RS92TXg9Z+qd3j95C9cmeuDYiY814dH4wgQIFAcASFcCBfCizPe9ZQAgWIIzD5uq2oAr78WuSa8UgvonV4/6YtCeDHOML0kQIAAgbYEhHAhXAhvawgpTIAAgdwJzDluq9o14dUZ7/rjwpNfnnz8L3NnMbBBZsJzfXg0jgABAsUREMKFcCG8OONdTwkQKIbA7C9sWevo0Gu8E16efIIQXowzTC8JECBAoC0BIVwIF8LbGkIKEyBAIHcCsz8fhfB64k7vffJJV+fOYmCDzITn+vBoHAECBIojIIQL4UJ4cca7nhIgUAyB2Ud/sHYX9PTyd7W+yScL4cU4w/SSAAECBNoSEMKFcCG8rSGkMAECBHInMPtzHwjR3/fo3mu1HF7qe274gFyewPopp12TOwsz4bk+JBpHgACBYgoI4UK4EF7Msa/XBAiMXYFXj9yiv3P1x5QN+CBUE3rfq5Prp5x+ba5R/Rw914dH4wgQIFAcASFcCBfCizPe9ZQAgWIIvPrZKIT33Q29f0q8PvXd957A+ilfvi7XwEJ4rg+PxhEgQKA4AmmH8PfNXCw27r/ueyV2majAuld+LHa5hXf9LXaZqED543vFL3ftj+OXiUoMeLZrqzsoTV+81U37t+stjQ/ld500mupi16UAAQIECHRO4NXPzOzczmLsacoZQngMLpsSIECAwFgQePGlV8LcufPDMktNb7k7QvhgKiG84SGEtzyMbEiAAIFcCbx6+MzGNeDVie+h14QPWO7g+qlnXZ8rh6GNMROe68OjcQQIEOgugWeeezHsfvAp4R+PPFlt+EpvWj7ss8tWYevN31tdvvG234eDjz1nkU79/voLwoTx48MPyquk1mEz4QOozYSndt6piAABAkUSeOXQzaq3Y+v/SfqA26RXb9KW0PLUs4XwIp1n+kqAAIFCCzz1zAvhZ9feFraZuV6YOnlSuPTy68PFl10bbr3inDB50oRww213hc+dckG4/ILjBzmt8Pplqn+khfAGi5nwhoWZ8EJ/reg8AQJdLPDqpzfrmwmvz3in8z71qzfkWs1MeK4Pj8YRIECguwUeefzpMHOnI8Kls44Oa62xcjWEH3/mt8NtP5u1SMf8HH0wiRAuhHf36Nd6AgQIhPDKwZtmwjD1HCE8E3iVEiBAgED2Aldcc1v4/OkXVkP3jOmLV0P4IcfOCh+auV6YOHFCWHvNVcLMDdcJ43p6qk8pMRNuJny4s9ZMePZjWQsIECAwGoFXDto0k5nwxb5242iam1oZM+GpUauIAAECxRL420OPhJ0POCl8fPuZ4cA9t612/k/3PRSuu+W3YdriU8NjTz4bfvSLm8PO224SjjlkNyF8yOlhJrwBUimPD6V13B29WN8gekuAwFgQePlTm1S7ET0NPLoyvP6KrgWPrglvLHd2/WJfF8LHwvmjDwQIECAQQ+DRJ54Jux10cljn7auGU47aJ/T0lIct/dOrbw3HfumicPeNF4aeco+Z8AFKQviA/1krjQ8ljyiLMQJtSoAAgXwIvHTAxn0JvBSq/9peu0fbMO+dXb/4N27KB0CTVpgJz/Xh0TgCBAh0n8ADDz0aPnHoaWHj9dcKxx66e/Wn5s1et935p7D/kWeGu677Zpg4YYIQLoQPe6r4OXr3fQ9oMQECBCKBf++/UfRcsloAXySB9xklsP515wnhzkACBAgQKIjA/X//V9hur2PDlpu8Jxy013ahXK7NgE+ZPDEsMW3x8P0rbgyrrPTGsNrKbw4vvvRyOOKE88L4cT3horOP9HP0IeeImfAGiBBekC8Q3SRAYMwJ/Hu/jRrXhPf9BL1SqdSeF57g8rRv3pJrSzPhuT48GkeAAIHuErjmpjvDZ074xiKNjp4TftrR+4azzv9RuPAHV/evf9tqK4UvH7t/eMNySwvhQnjTk10I767vAa0lQIBAXeDFfTZsYDT7KXp9iw6uF8KdgwQIECBAYIDAnLnzwtPPvhAWnzolTJ+2WP8ad0cffJqYCW94COG+QggQINCdAi/uvWFjxrs+853C+/Rv/SrXYGbCc314NI4AAQLFERDChfBmZ7sQXpzvAT0lQGBsCTy/5wb9l4TXL/1O4336hUL42DqT9IYAAQIEEhFIO4Qn0okmO13n3eNiV/e/dy6IXSYqsP0Fa8Uu939f+kPsMlGBxx6PbrQT77XEEgMfUtNa2dKkSeG99/+x+j9yXgQIECDQPQJRCK9eA15vcnQteArLMy6+ddRIL770Spg7d35YZqnpo97HSAXNhI8kZD0BAgQIpCIghA9mFsIbHkJ4KkNQJQQIEOi4wHN7vK+2z+rN0esXfSe/POPbt8XuyzPPvRh2P/iU8I9HnqyWXelNy4d9dtkqRPe16fRLCO+0qP0RIECAwKgEhHAhvNmJI4SPakgpRIAAgcwFnvv4+xp3R6/fFT2F9yUv+XXsvj/1zAvhZ9feFraZuV6YOnlSuPTy68PFl10bbr3inDB50oTY+3utAkJ4RzntjAABAgRGKyCEC+FC+GhHj3IECBDIp8Czu62fScOWvDR+CB/a0EcefzrM3OmIcOmso8Naa6zc0X4I4R3ltDMCBAgQGK2AEC6EC+GjHT3KESBAIJ8Cz+66fnUmvH53turzwVNYXup7t7cNcsU1t4XPn35huO1ns8KM6Yu3vb+BOxDCO8ppZwQIECAwWgEhXAgXwkc7epQjQIBAPgWe3nm9/oYNuCK8+lmSy0t/f3AIv/L634Qnnn5uWKTVVn5zWG+d1Qet+9tDj4SdDzgpfHz7meHAPbftOK4Q3nFSOyRAgACB0QgI4UK4ED6akaMMAQIE8ivw9E7vDbWJ7767opdCKsvL/PA3g1C+99MbQvTz8uFea63x1rDZ+9fuX/XoE8+E3Q46Oazz9lXDKUftE3p6yh0HFsI7TmqHBAgQIDAaASFcCBfCRzNylCFAgEB+BZ7acd0Bc971ue/k35e5bHAIb1XogYceDZ849LSw8fprhWMP3T2M6+lptWis7YTwWFw2JkCAAIGkBIRwIVwIT2p02S8BAgSyEXhqh3UH3B29fml4ZcDMeH2GPHrv3Pr/+PEdsTt8/9//Fbbb69iw5SbvCQfttV0ol2sz4FMmTwxLTHNNeGxQBQgQIEAg/wJCuBAuhOd/nGohAQIE4gg8+dH3DLt59bHhr7Gjdtf/x+XxQ/g1N90ZPnPCNxZpVfSc8NOO3jdOt0fc1kz4iEQ2IECAAIE0BIRwIVwIT2OkqYMAAQLpCTzxkffULwJP9X3Zn96ZXidHUZMQPgo0RQgQIECg8wJCuBAuhHd+XNkjAQIEshR4fNt3L3IX9KHtGXqX9E6sX+4KITzL465uAgQIEOgSASFcCBfCu2SwaiYBAgRaFHj8w+/uuyZ8mLuiV3+S/hp3TW9j/fI//22LLcxmMzPh2birlQABAgSGCAjhQrgQ7muBAAECY0vgsW3WaXSo1Pd8svrceP9y3yYdXL/8L4TwsXUm6Q0BAgQIJCKQdgifMCF+N+bNi18mKrHDxY3nj7a6h0cu+XOrmw7a7k3n7xi73AunXBO7TFTgr7c+FbvcUsuOj10mTJwU3nLj/4bo/8+8CBAgQKB7BB7bep1QCZUBM96lVJZff+Xvco1kJjzXh0fjCBAgUBwBIXzwsRbCB3gI4cX5ItBTAgTGlMAjW65d/QfUxuPH6o8hS/b99VcJ4WPqRNIZAgQIEEhGQAgXwpueWUJ4MoPOXgkQIJCwwCMfXLt/5juE2oPH6jPjSS6/8eq7Eu5Ze7s3E96en9IECBAg0CEBIVwIF8I7NJjshgABAjkR+NcH3llrydAHfye8/MZrhPCcnAKaQYAAAQJ5FhDChXAhPM8jVNsIECAQX+BfM9eq5e9S313QB8yE12bE+/J5h9evcN3v4zc2xRJmwlPEVhUBAgQINBcQwoVwIdw3BAECBMaWwD83e0ft4u/+qfD6FHjfe/1i8Q6vX+F6IXxsnUl6Q4AAAQKJCAjhQrgQnsjQslMCBAhkJhCF8Er0B746T+ealgAAIABJREFU512/GVul7z8GLHd4/Ztu+GNmfW6lYjPhrSjZhgABAgQSFxDChXAhPPFhpgICBAikKvDwJm/vr68+H17/IMnlN98ohKd6oFVGgAABAt0pIIQL4UJ4d45drSZAgEAzgYc3fnt1Jrz/mvD6td8Jv6948925PihmwnN9eDSOAAECxREQwoVwIbw4411PCRAohsBDG66ZSUdXvEUIzwRepQQIECDQXQJCuBAuhHfXmNVaAgQIjCTw0AZr9s2Eh1C7B1vfXdJLyS6/5db/G6lpma43E54pv8oJECBAoC4ghAvhQrjvAwIECIwtgQfft0bfTdkG3xW99niy5ndNb3f9W24TwsfWmaQ3BAgQIJCIgBAuhAvhiQwtOyVAgEBmAn9ff40BTyer3xV96Hs9p3du/Uq335NZn1up2Ex4K0q2IUCAAIHEBdIO4VMmx+/Sq7Pjl4lKbHf8yrEL/vprf41dJiqwyS8+HLvcg5+5OnaZqMCdt8+LXW755WqPqYnzKk2eFN7/wB9rj5r1IkCAAIGuEXjgvav3z3c3a/TQu6QP3W406//zN0J415wkGkqAAAEC2QkI4YPthfCGhxCe3bhUMwECBNoReGDd1TO5O/pb7/hzO81OvKyZ8MSJVUCAAAECrQgI4UJ401kSM+GtDCHbECBAIHcCf3v3f2fSprfeKYRnAq9SAgQIEOguASFcCBfCu2vMai0BAgRGEvjbu/47k5nwlf/33pGalul6M+GZ8qucAAECBOoCQrgQLoT7PiBAgMDYErh/7f+q3gW9frfztN5X/p0QPrbOJL0hQIAAgUQEhHAhXAhPZGjZKQECBDITuP+d/9U/E974R/dK9XnhSS6v+vv7MutzKxWbCW9FyTYECBAgkLiAEC6EC+GJDzMVECBAIFWB+96xaqO+obc5T3B51T8I4akeaJURIECAQHcKCOFCuBDenWNXqwkQINBM4C9RCG/2+O9K/fngofoIyuj/A4a+159vFnf9f/1RCHdWEiBAgACBEQWEcCFcCB9xmNiAAAECXSVw75oDZsJTbPlqdwvhKXKrigABAgS6VUAIF8KF8G4dvdpNgACB4QX+/LZVM7kmfPU/3Z/rQ+Ka8FwfHo0jQIBAcQSEcCFcCC/OeNdTAgSKIXDPGrWZ8Povz+u9Tnp59T+ZCS/GGaaXBAgQINCWgBAuhAvhbQ0hhQkQIJA7gT+tHs2E16/1rt0VPY3lt/1ZCM/dyaBBBAgQIJA/ASFcCBfC8zcutYgAAQLtCNy92qqhfnO1NN/XFMLbOWzKEiBAgEBRBIRwIVwIL8po108CBIoiEIXwSv/Ud2NGvHYb9OSW3/4X14QX5RzTTwIECBBoQyDtED5hQvzGzpsXv0xU4oN7LRe74M3fezx2majAh365RexyP9ni2thlogLz54+qWOxC5SmTwo4v3139fzYvAgQIEOgegT+sms3d0d9xn5+jd89ZoqUECBAgkJmAED6YXghveAjhmQ1LFRMgQKAtgd+vsmqohPq14JVQCqXa8tD36rXinVv/zvvNhLd14BQmQIAAgWIICOFCeLMzXQgvxneAXhIgMPYEfrfyqmleCt5/F/Z3/tVM+Ng7m/SIAAECBDouIIQL4UJ4x4eVHRIgQCBTgd+9tfGc8P4Z8GjGO5r5rs+IJ7C8zgNmwjM98ConQIAAge4QEMKFcCG8O8aqVhIgQKBVgd/+Z9814fWbs9ULLvKg8L67tHVo/bseMBPe6jGyHQECBAgUWEAIF8KF8AJ/Aeg6AQJjUuDOlVYNAx4MXr8deuLv737QTPiYPKF0igABAgQ6KyCEC+FCeGfHlL0RIEAga4E7VszmOeHvedBMeNbHXv0ECBAg0AUCQrgQLoR3wUDVRAIECMQQ+H8rDrgmvH7tdwrv733YTHiMw2RTAgQIECiqgBAuhAvhRR39+k2AwFgVuP1N9eeE1x8/Vu9pssvr/cNM+Fg9p/SLAAECBDooIIQL4UJ4BweUXREgQCAHArev0Pec8GbPB0/o8/X/aSY8B4dfEwgQIEAg7wJCuBAuhOd9lGofAQIE4gnc9sZVQqg+Kbz+qt8Wfeh7Z9e/719mwuMdKVsTIECAQCEFhHAhXAgv5NDXaQIExrDArW9oXBNev0t6pe+a8CSXN3jUTPgYPq10jQABAgQ6JSCEC+FCeKdGk/0QIEAgHwK/en3tmvD+4B1qM+CN5Vo7O71+g0fNhOfjDNAKAgQIEMi1QNohPE2M96w/MXZ1d/x6buwyUYFtv/jW2OWuOP5vscukWaA8ZVLY8eW7Q2ngLxrTbIC6CBAgQGBUArcsn83d0Td63Ez4qA6YQgQIECBQLAEhfPDxFsIbHkJ4sb4L9JYAgbEjcNOy9WvCm10LnsznGz9hJnzsnEV6QoAAAQItCbz8yuzw/IsvhRnTXxemTpm0SJmXXn41LFi4MCwxbfH+dUK4EN7s5BLCWxp2NiJAgEDuBG5atjYTXrs5WyWUSrWfoie9vMmTZsJzdzJoEAECBAgkI/Dq7Dlhl0+dFP764CP9Fey87SbhqAN3CT095RCtP/Kk88NNt/+huv5tq60UZp10cFhqxrTq/Vl+UI7+xXzsvfwcvb1jKoS356c0AQIEshK4YZmBf9drQbzxSm5506eE8KyOuXoJECBAIGWBaAb825ddGz60xXph+f9YKvzmd/eE/Y88K1w66+iw1horh299/5fhx1feEi6ddUyYPGlC+ORRZ4cVV1gunPjZPYXwIcfKz9EbIEJ4ygNZdQQIEOiQwP8s/RrPCe+7S3olmiEf7nnhbazf/GkhvEOH0G4IECDw/9u78zifqseP4+8xZux7ZMueLUv2LZHdZMlurGXLvmYpyRalRIsifpZEwrfsQgahEJKlJKVQCNnXsczvcW7NZPjMmLnuzHyW1/2nL3PP9jyXx/ft3HsOAp4m8Ovvf6rBs0O1ZOYY5cudTU07D1ftqmXUuXU9ayirN3yr/iM+0L71M61X01gJ/2+GCeGEcE/7805/EUAAgbsFVj9UwHXAtoL3P+viLgP4A/681mm+CedpRAABBBDwMYE/jp/SgqXrtXbTTgVVK6+eHRpZAmXqdtWrgztaQdxcP/78u5p1GaFvlr2v1ClTEMLveE4I4YRwH/trg+EigIAXCqzOkDC7o9c5w0q4Fz5ODAkBBBBAIDqB/QcP68OPl2nnngOqUuFxDe/fXokT+6vIU8/pg9f6qUqF4lbx8JXytfPfUuZMGQjhhHCXj5V/8mRqful7jijjrx0EEEDAwwS+SFcgfA82WX+Jmw1gIpbA4+7XdQnhHvak0F0EEEAAAccEzl+8rBrNB2hYv7ZqUKuStRI+Zkgn1apSmpXw+yizEs5KuGN/EKkIAQQQSCCBlekK/hu8wwN3/Pw36Bwr4Qk05TSLAAIIIOAOAkFtBqtR3crWd+Dmm/A6T5VVp1ZPW13jm/CoZ4gQTgh3hz+/9AEBBBB4EIEVaRLm1JOnzxPCH2TeKIsAAggg4EECu/Yd1P6DR1SjcimlTZ1CK0K26uVx0zX73ZdUqlh+TZu7XP9b/pW1O3ryZEmsndPZHd31BBPCCeEe9EefriKAAAIuBZan+feb8PDdz/89JzxiM7Y4+nX9C4RwHkkEEEAAAR8R2Lv/kLq/OFFnzl2MGPHgHsFq16y29evLV67phVGTtXHrbuvXRQrk1ntj+ijTQ2k5ouyuZ4QQTgj3kb82GCYCCHixwNJU/62Ex92p4P8A3ll/g4uEcC9+rBgaAggggMDdAmFhYTp34ZLMmeFms7WAxP73IJlvxW/cuKmH0qeJ+JnZq4Ujyv6jIoQTwvnbBQEEEPB0gaUpE2Z39IaXCeGe/uzQfwQQQACBeBAghEdGJoQTwuPhjx1NIIAAAnEqsDj5v7ujR9XKPweFR33Z/PkzhPA4nVcqRwABBBDwEgFvDuFeMkUJNoxEyZOqxaXdHFGWYDNAwwgggIA9gUXJw1fCJVmB2k/mjTlzWllc/rrxVVbC7c0YpRBAAAEEfEqAEO5T0x2rwRLCY8XFzQgggIDbCHye9J9vwv/N3//8j3j4deNrhHC3eQjoCAIIIICA+woQwt13bhK6Z4TwhJ4B2kcAAQTsCXyWtIC18arfHSvg8fHrptfth3Czp83Z8xeVPm1qpUie1N7A71PKL8y8D8CFAAIIIIBAAgsQwhN4Aty4eUK4G08OXUMAAQSiEVgYmDDnhDcLjX0Iv3L1mlr3eFU/H/ojYkStGlXXkJ6t5e+fyNF5JoQ7ykllCCCAAAJ2BQjhduW8vxwh3PvnmBEigIB3CiwMKKiw8HfQrT3Y/vkmPHwztvDzwsNH79TPm9+MfQg3K+Cz5q9SwzqVlPXhh/TNjn3qOniCPn7vJZUsmt/RCSKEO8pJZQgggAACdgUI4XblvL8cIdz755gRIoCAdwrMT5wwK+EtbITwu2fg19//VINnh2rJzDHKlzuboxNECHeUk8oQQAABBOwKEMLtynl/OUK4988xI0QAAe8U+NQ//Jtw/fttePz8N/h27FfCw2fgj+OntGDpeq3dtFNB1cqrZ4dGjk8OIdxxUipEAAEEELAjQAi3o+YbZQjhvjHPjBIBBLxP4BO/AnccRxZ1AP9n+3Tnfn53CF+25hudOHXGJXDh/LlUqUyRiJ/tP3hYH368TDv3HFCVCo9reP/2CghI7OjkEMId5aQyBBBAAAG7AoRwu3LeX44Q7v1zzAgRQACBuBSY+/lamRVuV1fJoo+q5pOl7/nR+YuXVaP5AA3r11YNalVytHuEcEc5qQwBBBBAwK4AIdyunPeXI4R7/xwzQgQQQMAdBYLaDFajupXVuXU9R7tHCHeUk8oQQAABBOwKEMLtynl/OUK4988xI0QAAQQSWmDXvoPaf/CIalQupbSpU2hFyFa9PG66Zr/7kkoVY3f0hJ4f2kcAAQQQiAMBQngcoHpJlYRwL5lIhoEAAgi4scDe/YfU/cWJOnPuYkQvB/cIVrtmtR3vNSvhjpNSIQIIIICAHQFCuB013yhDCPeNeWaUCCCAQEILmDPMz124JHNmeOZMGRSQ2D9OukQIjxNWKkUAAQQQsCNwcOlX9xTzT5RISQL9dPOWFHrjVoyrTZTIT4n9E8WqjKk8MMBfN2/e0m2zU2sMrwdq69Zt3Y5FY17blp+s/7Nz3cUc+/n7K9/TT8RwNrgNAQQQQAAB9xYghLv3/NA7BBBAAAEEEEAAAQQQQAABLxIghHvRZDIUBBBAAAEEEEAAAQQQQAAB9xYghLv3/NA7BBBAAAEEEEAAAQQQQAABLxIghHvRZDIUBBBAAAEEEEAAAQQQQAAB9xYghLv3/NA7BBBAAAEEEEAAAQQQQAABLxIghHvRZDIUBBBAAAEEEEAAAQQQQAAB9xYghLv3/NA7BBBAwGcEtu78UecvXlbtqmViPGY7ZUzldsrZKUNbMZ5KbkQAAQQQQMBnBAjhPjPVDBQBBBBwb4EuA8dr175ftP2LKTHuqJ0ypnI75eyUoa0YTyU3IoAAAggg4DMChHCfmWoGigACCLi3gJ2Qa6cMwTjycxCfhqbly1euqU6rgapUtqhef6mLez+U9A4BBBBAAIE4ECCExwEqVSKAAAIIxF7AThi0U4YQnrAh/Nr1UI17f57y5cqq1o1rxv5BoQQCCCCAAAIeLkAI9/AJpPsIIICAtwjYCdR2yhDCEzaEe8vzyjgQQAABBBCwK0AItytHOQQQQAABRwXsBGo7ZQjhhHBHH1wqQwABBBBAIJYChPBYgnE7AggggEDcCNgJ1HbKEMIJ4XHzBFMrAggggAACMRMghMfMibsQQAABBOJYwE6gtlOGEE4Ij+NHmeoRQAABBBCIVoAQzgOCAAIIIOAWAnYCtZ0yhHBCuFs88HQCAQQQQMBnBQjhPjv1DBwBBBBwLwE7gdpOGUI4Idy9nnx6gwACCCDgawKEcF+bccaLAAIIuKmAnUBtpwwhnBDupn8E6BYCCCCAgI8IEMJ9ZKIZJgIIIODuAnYCtZ0yhHBCuLv/WaB/CCCAAALeLUAI9+75ZXQIIICAxwi8Pe1/+v3oCQ0f0F7p0qSKUb9NmSN//qUJI3rE6P7wm+yUs1PGtGennJ0y92vr9u0whYWFyd8/USSr6NqKqozdtmI1SdyMAAIIIICAlwoQwr10YhkWAggg4IkCFy9dUfl63VWtUgk1qF1JlcsVU9IkgdEO5eatW9r23f77DrdEkXxKnixppPsO/HpU8xaFKExh6tAySDmzP6wjf55UiuRJlSFd6nvqjM+2TOOx7d+dHT55+px+O3o84rdCNu3UnydOq12z2nokS0ZlzfzQPeOzU8ZUYrfcfSeNGxBAAAEEEPBCAUK4F04qQ0IAAQQ8VcCs1G7//oC+WL9NC5aut0Jz/VoVVa9GBT3+WD4lSuR3z9AuXb6qp5r2u+f3r1y9Fil0L/hwuHLnyBJxnwnUTzXpqyIF8+jGzZs6eeqsln40ViPGz1JAgL+G9mmboG3Z6V94h4eMnapla76J8jEY3CPYCuN3XnbKmPJ2y3nqM0q/EUAAAQQQeFABQviDClIeAQQQQCBOBIaPn6kzZy8oICCxVm/YroczplPTelVVr0Z55cj2cLRtmgDbrPNw9e3cTFUqFHd57/6Dh9W083DtXD1Vfn5+eqJhL332fyO1c8/PWvPVDk1+/d5g76qiuGrLbv9OnzmvKo376Iu5byhHtkwRXZ63OESHDh9z+Y8LdsqYiu2Wi5MHhkoRQAABBBDwEAFCuIdMFN1EAAEEfE3AhHATtjsGB+n8xctau3GnXp/0iQrkfURzJg29L8esBau058dDmjCiu8t7z56/aAXvr5dMUto0KWU2eWvfvI4V/Feu2xbjEG4qj4u27Pbv2InTqtnyBe0Oma7E/v4xCuF2ypiK7Za77+RxAwIIIIAAAl4sQAj34sllaAgggIAnC4SHcPNd+Kr127Rw2QadOXdRrRpVd7mae+dYQ0NvaMRbs+Tv76/Rgzq4ZDAr2G17jVW+XNlUq0ppTZ2zXIUezant3+9XtSdKqleHxjHii6u27PbPbKb2w8+/q2C+HApI/F8IN6vWpq+uvgW3U8bg2C0XI1huQgABBBBAwEsFCOFeOrEMCwEEEPBkgeMnz+jFsVO1/fufrGGYcNw46EkrLD+UPk2kobn6Jjz8e/AZEweraMHcLikuX7mmOq0GRvqZefW9dLECGtq3rdKkSnFPufhsy07/wjts3hwwu56v3bjD+ocL49etXUNVr1zSpcX10Bua/NGS+z4ybZrUjOQfXblihfNaG+xxIYAAAggggEBkAUI4TwQCCCCAgNsIXLseqq6DJ1jhO33aVGpWv6qCqpVXvtzZouyjqx3LU6dMrkL5c0Z6HduJQcZnWw/S376vTLK+/+7WvqFeeXOmWjeuobmfr9W7o3upQunH7qn66rVQDXtjeqTfD71xQyGbvrOCe2BAgPWzF7q1UOaM6SPuc1XuxMkz2rXvoPUGgvmHEy4EEEAAAQQQIITzDCCAAAIIuKnAlavX9dp7c1W/ZkWVKpb/njOtnex2dMeNZc6YTnlzRR/8j/55UpeuXFO2zA9Z/2AQ3WWnLVNm+65/3gSI7ir+mDl6LUnELWYVvGL9Hlo7/y1leTiDKj/TSyvmjNPcz7+0zmEfN/T5+1UZ8fNeQ99RhdJFrE8AYnqZf0gJajNYE0f2VPHCeWNajPsQQAABBBDwGQFWwn1mqhkoAggg4P4CdoPn7h9/1eJVm7Vz9wGZOsKvBrUqqWu7Bi4HHtWr5eZmsxlc/+ebuyxnVnmHjJmqP46fivh5o7qVNXzAs5G+wb6zcHTHqEXVVlRl7u7U3Uev/XzoD7Xu8aq2fzHFujU8hJtzwjdt26MJI3rE+EH4ZFGIVSamO8WHV/zSa9OU6aF06tu5aYzb4kYEEEAAAQR8RYAQ7iszzTgRQAABDxCwEzzDz9OuUOox61XrgMSJI0aaM/vDKlooT4xHfvL0OTXpNEzzpwx3uYGZ2disevP+qlqxhJo3eEpZMqXX9z/8opFvzdJzLeuqQ8ugGLcVk6PNYlzZHTf+ffaCnmzUWxsXvasM6VJbIXxg95b6v7krrFBsNp27+zIbrP125FjEb4eFydqRfuLUhSpboqB6d2wSq66YV9/NJwHmjHcuBBBAAAEEEIgsQAjniUAAAQQQ8GiBA78eVeOOw7QnZIYjr6/3H/G+tbN4lzb173Exq8yNOrysrcs/UKqUySN+bo4o27rzB00ZNyBWlvc72sxVZSdOndH5C5eto9qiup7t+7q1KVq7ZrWtEJ4uTSrVq1lBz7Woa527fvd18dIVla9371FutauW0cDuwdY/NkR1mbD+9bf7tPenQ7p163bEbaWKParaVcvGyoObEUAAAQQQ8AUBQrgvzDJjRAABBLxYwGwOVrpOFy2f/Zpy58jywCMdNXG20qdJpZ4dGt1TV/i52Es/Gqu8ObNG/HzkhI90+fJVvTGsa4zbj8nRZqYyE7h37v1ZW3f+qM3f7tHhP/6ywvXgHsExasv4JEsaeN97zY7yd16BgQEx2tiuaefhMiHefMN/Z8AvU7ygFfy5EEAAAQQQQCCyACGcJwIBBBBAwG0EzMZsXQaOv29/Xh/aRdmzZLTuu3Hjptr1ec0KjHcfwVUgzyMudwO/s4Gjx05qx+4DunDpinJlz6xKZYtEGT7DwsLUbcgEmRXxOlXLWhuf7dzzs77cuEP/N35glG3ZOdrMhOdn+7ymfQd+s8ZatkQhlS5eQI8/lk85smWSn5+fSydzbNi0OcvvaxjcqLr1urpdC1Pu0JHjqt/uRW1bMVkpUyS7b5vcgAACCCCAAAISIZynAAEEEEDAbQRMoP5s5cb79qdutXIR53ibsNrr5XdclnmqYgnreK6oLhOezXFeJuSGb7RmztSe9faQKEOlCdSz5q+yNiw7d+GS8uTMqnZNa0Ub9u0cbWbC9LBx07UiZKuqVnxctaqU0ZPli1mvlkd3GY+hr0+7r+GgHsGRjhuzY3Hu/CVVathTm5e8d99+3bdD3IAAAggggICPCBDCfWSiGSYCCCCAQGQBE4wr1Ouh3h0bq23TWta30wumjrTOyzZHa/Xq0NgtyEyo3rJjn9Zs3GGd2138sbzWt92VyhRxrH92Lcw34M8Pfku5H8msBrWfiNSfDGlTudzczrFOUxECCCCAAAIeKkAI99CJo9sIIIAAAv8I2DmD25Q78udJ1W09SHvXzVSiRH4RR3lt3rZXi1dt0tQ3X7iH2KxOT/5oiUv6YoXzWpuhRXX9duS4ln35jTZu3aP9Bw/L3N8p+Ol7XqF3Vd70dd3m77Rg2Xrrm/ChfdpGeXa3nWPe7FiYfka1oZv5mTlb3PSTCwEEEEAAAQQiCxDCeSIQQAABBDxawM4Z3GbAJswGtRms3SHTrW/Aw8/T/nD2UqVIkUzd2ze8x8WsSpuV8juv0Bs3rBXqV/q1U4uG1VxaXrseqpotBih71kxqUKui0qRKqS07f9DnKzfq/bF9rdfN775MmJ7zvy+1fO0WK7Q/Xb28tdt4xTJFot1ozc4xb3YswvtrjjdzdZlP1qP6bt2jHzg6jwACCCCAwAMKEMIfEJDiCCCAAALuJ2ACbMuuo9T92WeiXJ02358/XrOTZkwcrHIlClkh3Bw7ZgLpF3PfsDY/i+nVa+g7qlC6SJSr0z/9ckRNOr2iL+aOU45sD0dUO2j0FF0LDdW7o3vf09TlK9dUNuif3dYbBz0pcw56kYK59UjWjI6HWycszG7v4df6b3bp2Im/re/x/f39HTk6LqZzwX0IIIAAAgi4uwAh3N1niP4hgAACCNgSmL1wtb7be1Bvj+oZZfmvtuxWiuRJrV3Hp81dbh07ZsJ0TI70urPSTxaFWBu1TX69n8u2zDFjFRv00MZF70bakXzRF5u0esO3UZ4vbl5/37v/kL79/id9s32fdu07qOTJkqpfl2ZRBn5bWJLsWny6ZJ2MtfnHC1fXgK7N1aFlkN1uUQ4BBBBAAAGvEyCEe92UMiAEEEDA9wTOX7z836DDpAuXLuuN9+cpSZJAjX+lm2Mg5tXr344ci6gvLEwybU+culBlSxRU745NXLZlVuZbd39VuXNmUY3KpSLu+WzFRgUE+KtBrUrW75UvWTjao77Mq+YmiJurcrlijo3LbkXmSLkydZ/X2Bc7K3+e7BEr9CtDtlq7zXdpU18ZM6S95yg0u+1RDgEEEEAAAW8QIIR7wywyBgQQQMCHBaLbHGzh1BEqnD+XYzpRtVW7ahkN7B6sLJnSu2zLvFpev/2L9+3HzIlDlDP7f6+rH/j1qOYtClGYwqzVZPMzs4maWb2/+4zv+1YeBzeEf0v+w4ZZkWqftzhEhw4fY2O2ODCnSgQQQAABzxcghHv+HDICBBBAwKcFzOr0H8dPRjK4cfOWOr/wpiaO7GkdN+bkdeXqtUjVBQYGWBu7OX2Z1fOnmvRVkYJ5dOPmTZ08dVZLPxqrEeNnWavn7rDzuPmWfO6itWrZsJqSJgmMIDAbyZkzxCuUfsxpFupDAAEEEEDA4wUI4R4/hQwAAQQQQMCVwNQ5y/T70RPWq9JOX0ePndSO3Qd04dIV5cqeWZXKFnE8iJsg27TzcO1cPdV6zfuJhr302f+N1M49P2vNVzui/P7c6bFGV190x8PdWa5EkXzWt+xcCCCAAAIIICARwnkKEEAAAQS8UmDc+/P016mzmjCiu6Pj+3LjDvV9ZZKyZ8loffdsrkKP5tSst4dE+z13bDtx9vxFK3h/vWSS0qZJqS4Dx6t98zo6c/aCVq7b5hYhPLrj4e4M3Qs+HK7cObLEloD7EUAAAQQQ8EoBQrhXTiuDQgABBHxHwLweblaM77xO/X1e5vfDjx9zSsOs/Fao10O9OzZW26a1rGPNFkwdaZ0dbl5779WhsVNNybTVttdY5cuVTbWqlNbUOcthUSZoAAAO1UlEQVStsL/9+/2q9kRJR9tyrNOS1e9mnYerb+dmqlKhuJNVUxcCCCCAAAJeIUAI94ppZBAIIICA7wqY77/XfLU9EkDqlMlVosijjq5MmwbMpmh1Ww/S3nUzlSiRnxXCV8wZp83b9mrxqk2a+uYLjk2E2cytTquBkeoLCEis0sUKaGjftkqTKoVjbTld0awFq7Tnx0OOv4XgdD+pDwEEEEAAgYQQIIQnhDptIoAAAgh4pED4buC7Q6Zb34CHh/APZy9VihTJ1L19Q48cl5OdDg29oRFvzZK/v79GD+rgZNXUhQACCCCAgFcIEMK9YhoZBAIIIODbAkvXfK33Zy62dhEf3v9Z6zXodZu/s86oLlooj2M4Zjfwx2t2injN3YTwVCmTy4TzL+a+oRzZMjnWlquKTMAN2fydzCp503pV4rStmFTu6ptw8xmA+R7cfApQtGDumFTDPQgggAACCPiUACHcp6abwSKAAALeJ2ACadmgrurdsYlu3bqlmfNXacvy9zVpxiKd+vucxgzp5Oigv9qy2zqnu3TxApo2d7ny5syqCqWLKFnS/47oepAGj/z5l9KnTR3pVfoTp87o8xUbrbGZkGtWmBsHPfkgzThS1tXu6OZTgEL5czq+W7wjHaYSBBBAAAEE3ECAEO4Gk0AXEEAAAQTsC4Qf5bUnZIb8/ROpdvBAvTO6lw4dPu74d9qml4eOHJefFLHb958nTitt6pRWMHfi+mjhausfEIKfqaZSxQpoyerNWr1hu/Lnya7WjWuqbrVyjrXlRH+pAwEEEEAAAQRiJ0AIj50XdyOAAAIIuJnA1WuherJRb4Ufg9Vr6DtqWq+qjv11Wlt2/qB3R/d2rMfhu6O/3LetGtaupFETZ2v+knXW69efTh6mvLmyPXBbpo2NW3Zrzmdfatuu/VZ9PTs0Ute2DazzwrkQQAABBBBAwLMFCOGePX/0HgEEEPB5geuhN6wjsZIlTaLypQrLnOOdOWN67f3pNw3o2lwtG1ZzzOjosZOq02qQvl87Xaf/PqcaLQZo0tg+Ctn0nQIDA/RKv3aOtWUq+vnQH/p0yTor6JvX3ts0raWnq5dnJdxRZSpDAAEEEEAgfgUI4fHrTWsIIIAAAg4LmJXwkRNmRao1IHFiFSucR02CqlhHiTl1/XH8lIK7jdKmxe9pZcg2jZ/yqdYtnKjVG77VZys2OnpE2Z19Pn/xspas2ixz9Ndfp87q1cEd1ahuZaeGRT0IIIAAAgggEI8ChPB4xKYpBBBAAAHPFzDfnLdpUtP6Tjtvrqwa+cJz1jfcx0/+7fgmcHdrmVfVzZnkJpSb1+G5EEAAAQQQQMDzBAjhnjdn9BgBBBBA4A4BVzt0h/84c8Z0jnynfSf4lh0/6I0P5ikwIEBvvtJNj2TNqAEjJ1sr05XLFXV0bsxqe6qUyVS5XDGdv3BZG7fuVo7sD6t44byOtkNlCCCAAAIIIBB/AoTw+LOmJQQQQACBOBBwdVa1acYc5dUxOEj9n28eB61GrtK8In7teqhyZn/YsbbMa/al63TRR++8aB2H1rbXWP30yxFrXFPG9beCORcCCCCAAAIIeJ4AIdzz5oweI4AAAgjcR8CsjpvN2vp2bqYqFYo76nXh0hWZ1fBfDx+LqHfPj7/o9JkLqvZESZUvWVgliz76wG2a+lt2HaVvV062Nmhr3HGY1s5/SyvXbdOBX47ojWFdH7gNKkAAAQQQQACB+BcghMe/OS0igAACCMSDgNnEbM+PhzRhRHdHW2vU4WVduXrdOrfb799N334/ckKXrlxVkYK51aBWJdWoXOqB2zx7/qJqtRyobSsma8Gy9frk87Va+tFYa0O4pWs2a8q4AQ/cBhUggAACCCCAQPwLEMLj35wWEUAAAQTiWCA09IZGvDVL/v7+Gj2og2Otmd3RzcZs362ZpiSBARH1zlscokOHj2lon7aOtWUqCu4+WhkzpNGuvQcV3KiGurdvqOHjZypJYKBe6t3a0baoDAEEEEAAAQTiR4AQHj/OtIIAAgggEEcCrr4JN99NJ0+WVDMmDlbRgrkda/nvsxf0ZKPe2rFqqpIlDYyod8HS9Tp05LiG9GzlWFumopOnz2nW/C8UEJBYnVo9rZQpkumjBautDeDy5srmaFtUhgACCCCAAALxI0AIjx9nWkEAAQQQiCMBV7ujp06ZXIXy51Rif/84apVqEUAAAQQQQAABewKEcHtulEIAAQQQcCMBswrtJyl3jixWr/48cVppU6dUiuRJ3aiXdAUBBBBAAAEEEJAI4TwFCCCAAAIeLWBWwivU66GX+7ZVw9qVNGribM1fss56Hf3TycN4bdujZ5fOI4AAAggg4H0ChHDvm1NGhAACCPiUwNFjJ1Wn1SB9v3a6Tv99TjVaDNCksX0Usuk7BQYG6JV+7XzKg8EigAACCCCAgHsLEMLde37oHQIIIIDAfQTMjuXB3UZp0+L3rOO7xk/5VOsWTtTqDd/qsxUbNfXNFzBEAAEEEEAAAQTcRoAQ7jZTQUcQQAABBOwKmGPD2jSpqdUbtitvrqwa+cJzmjRjkY6f/FtjhnSyWy3lEEAAAQQQQAABxwUI4Y6TUiECCCCAQHwLbNnxg974YJ4CAwL05ivd9EjWjBowcrIa1a1sHefFhQACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAggggAACCCCAAAIIeL0AIdzrp5gBIoAAAggggAACCCCAAAIIuIsAIdxdZoJ+IIAAAgh4rMCNm7e0aevuaPv/UPo0KlY4b5T33L4dpna9x+q5FnVVvXJJj7Wg4wgggAACCCAQvQAhnCcEAQQQQACBBxQ4f/GyKtbvEW0tNZ8srbdH9Yzynlu3bqtY9Q4aPuBZNa9f9QF7RHEEEEAAAQQQcFcBQri7zgz9QgABBBDwKAGzGh5+LVy2QWPe+VibFr+nVCmTW7/t5ycl9vcnhHvUrNJZBBBAAAEEnBcghDtvSo0IIIAAAj4uMH/JOo2aOFtbln+g1P+GcEOybM03mvHpSv186A/lz5NdHYOfVr2aFSwtVyvhm7bt0YcfL1PzBlXVoFYlXbx0Re9O/0whm7/TX6fOqlyJQhrUI1gF8+Ww6hj2xgxlSJdat2/f1vK1WxSQOLGCn6muVo2qKzAwwMdnheEjgAACCCDgHgKEcPeYB3qBAAIIIOBFAq5C+IqQrRo0eooqlSmiOk+V1ar13+rr7fv05rBuCqpe7p4QvmXHD+r0wptq0bCaXu7TVmFhYWrVfbTOXbikVo1rKH2aVJrz2Zc6dOS41i2cYK24N+08XPsPHlaJIo+qVpXSOnrspD5ZFKIp4waocrmiXiTMUBBAAAEEEPBcAUK4584dPUcAAQQQcFMBVyE8qM1gJU+WVP+bNjKi1406vKzroTe0cs64SCE8T44sat/nNbVsWE1D+7RVokR+Wv/NLvV86R198sEwFf93gzezom7qeGd0L9WoXMoK4dmzZNTEkT3kZ95/l9Sg/UsqV7KQVQ8XAggggAACCCS8ACE84eeAHiCAAAIIeJnA3SHcBO2StTqrU6un1a9Ls4jRTvhwgabPW6lda6bJ39/f2pitdtWyWr3hWzWqW1mjB3WICNNTZi/VezM+V6FHc0aUv3XrlvVq++AewWrXrLYVwosWyqPh/dtH3NNtyETrf09+vZ+XKTMcBBBAAAEEPFOAEO6Z80avEUAAAQTcWODuEH75yjWVDeqqPp2aqEub+hE9nzx7iSbNWKQdq6YqMCCxFcLNZVbMs2RKr4/fG6o0qVNYv/f2tP9p2tzlmjKu/z0jz5k9s3Jky+QyhPca+o5u3rpNCHfj54WuIYAAAgj4lgAh3Lfmm9EigAACCMSDgKvX0Ss/00t5c2XTrLeHRPSgba+x+v3ocWsX9fCN2bq1a6i61cqqZbfRypc7m6a/NdAK5UtWf62XXpumJTPHWL9/52W+Fzevn7taCSeEx8OE0wQCCCCAAAKxECCExwKLWxFAAAEEEIiJgKsQblaxzWr2823rW99vmx3OzSvm5vV085r63buj7/nxVwV3H21t5DZpTB+ZI9Dqt39RSZMEanCPVsr1SGb9fvSElqzerPq1KuqpiiUI4TGZHO5BAAEEEEAggQUI4Qk8ATSPAAIIIOB9AuEhfOvyDyLOCQ8NvaHxUxZo7udfRgy4bdNa6t+lmXV82O3bYSpa7TmNeOFZNatX1brH7J7eZeB46zvxCSO6Wzuhvzpxtrbt2h9Rh/lGfMyQTiqQ9xG1eH6kChfIFemb8N7D3rUC/vtj+3ofNCNCAAEEEEDAAwUI4R44aXQZAQQQQMBzBa5eC9WJk38rc6YMSpY00NZArl0P1ekz55UuTSqlSJ7UVh0UQgABBBBAAIGEESCEJ4w7rSKAAAIIIIAAAggggAACCPigACHcByedISOAAAIIIIAAAggggAACCCSMACE8YdxpFQEEEEAAAQQQQAABBBBAwAcFCOE+OOkMGQEEEEAAAQQQQAABBBBAIGEECOEJ406rCCCAAAIIIIAAAggggAACPihACPfBSWfICCCAAAIIIIAAAggggAACCSNACE8Yd1pFAAEEEEAAAQQQQAABBBDwQQFCuA9OOkNGAAEEEEAAAQQQQAABBBBIGAFCeMK40yoCCCCAAAIIIIAAAggggIAPChDCfXDSGTICCCCAAAIIIIAAAggggEDCCPw/DD/QirB2LY4AAAAASUVORK5CYII=",
       "text/html": [
-       "<div>                            <div id=\"435982b5-4ef7-425e-b8b4-343ae8a75879\" class=\"plotly-graph-div\" style=\"height:600px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"435982b5-4ef7-425e-b8b4-343ae8a75879\")) {                    Plotly.newPlot(                        \"435982b5-4ef7-425e-b8b4-343ae8a75879\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"z\":[[-0.01373291015625,-0.00787353515625,-0.001033782958984375,-0.0165252685546875,0.01230621337890625,-0.002727508544921875,0.01520538330078125,0.01198577880859375,0.0038299560546875,0.02197265625],[-0.026519775390625,-0.01410675048828125,-0.01309967041015625,-0.0224456787109375,-0.0007772445678710938,-0.006336212158203125,0.0199737548828125,0.0178680419921875,0.025726318359375,0.0309600830078125],[0.040802001953125,0.0269317626953125,0.00974273681640625,0.00969696044921875,0.01043701171875,0.033538818359375,0.057464599609375,0.059967041015625,0.08148193359375,0.05206298828125],[0.0246734619140625,0.07452392578125,0.00920867919921875,0.0048828125,0.0293426513671875,0.01116180419921875,0.0428466796875,0.0189056396484375,0.049835205078125,-0.04742431640625],[0.067626953125,0.00673675537109375,-0.0290069580078125,-0.00276947021484375,0.02008056640625,-0.0093994140625,0.00818634033203125,0.035614013671875,0.0576171875,0.00804901123046875],[-0.375,-0.160400390625,-0.043121337890625,-0.07293701171875,0.1214599609375,0.08563232421875,0.05218505859375,0.019775390625,0.06298828125,-0.060943603515625],[-0.1912841796875,-0.06927490234375,-0.035186767578125,-0.0784912109375,0.161865234375,0.0687255859375,0.08709716796875,0.0859375,0.143798828125,0.040008544921875],[-0.13720703125,0.005130767822265625,0.038238525390625,-0.032562255859375,0.2120361328125,0.11273193359375,0.1412353515625,0.1171875,0.19287109375,0.06414794921875],[-0.1470947265625,0.04315185546875,0.1473388671875,0.00804901123046875,0.0772705078125,0.0101470947265625,0.06817626953125,-0.00627899169921875,0.07073974609375,-0.06695556640625],[-0.1312255859375,-0.317138671875,0.00261688232421875,-0.48876953125,-0.02545166015625,-0.411376953125,-0.060516357421875,0.037506103515625,0.07952880859375,-0.09100341796875],[-0.0743408203125,-0.486083984375,-0.101806640625,-0.6123046875,-0.2322998046875,-0.732421875,-0.1873779296875,-0.03607177734375,0.019134521484375,-0.334716796875],[-0.2646484375,-0.5947265625,-0.03753662109375,-0.564453125,-0.18408203125,-0.66015625,-0.33447265625,-0.16455078125,-0.07037353515625,-0.364013671875],[-0.58544921875,-1.064453125,-0.1976318359375,-0.8271484375,-0.44384765625,-0.8232421875,-0.4990234375,-0.401611328125,-0.271240234375,-0.59033203125],[-0.337890625,-1.1025390625,-0.619140625,-1.0126953125,-0.7880859375,-0.962890625,-0.5986328125,-0.572265625,-0.387451171875,-0.69384765625],[-0.74169921875,-1.2421875,-1.0068359375,-1.3427734375,-0.7626953125,-0.98193359375,-0.66357421875,-0.64990234375,-0.54296875,-0.63623046875],[-0.85888671875,-0.9267578125,-0.7216796875,-1.0439453125,-0.1610107421875,-0.5556640625,-0.1453857421875,-0.1002197265625,-0.1180419921875,-0.18701171875],[-1.78515625,-1.71875,-1.6162109375,-1.8037109375,-1.0517578125,-1.1552734375,-0.6044921875,-0.55126953125,-0.50732421875,-1.1171875],[-1.875,-1.3662109375,-1.4755859375,-1.583984375,-0.77734375,-0.986328125,-0.389404296875,-0.15234375,-0.05303955078125,-0.76953125],[-1.9140625,-1.2138671875,-1.373046875,-1.3955078125,-0.420166015625,-0.7509765625,-0.1842041015625,-0.0595703125,0.013580322265625,-0.490478515625],[-2.287109375,-1.6689453125,-1.7451171875,-1.8095703125,-0.48828125,-0.9931640625,-0.2293701171875,-0.107421875,-0.0343017578125,-0.646484375],[-3.361328125,-2.525390625,-2.353515625,-2.380859375,-0.9658203125,-1.74609375,-0.982421875,-0.98046875,-0.73291015625,-1.203125],[-2.7109375,-1.9794921875,-1.923828125,-1.984375,-0.51611328125,-1.21484375,-0.262939453125,-0.461181640625,-0.2132568359375,-0.69580078125],[-4.13671875,-3.61328125,-3.314453125,-3.80078125,-1.75390625,-2.408203125,-1.24609375,-1.63671875,-1.3740234375,-1.796875],[-3.673828125,-3.32421875,-2.787109375,-3.1875,-1.3681640625,-1.8369140625,-0.435302734375,-0.96435546875,-0.95654296875,-1.3740234375],[-5.078125,-5.08984375,-4.24609375,-4.58203125,-2.765625,-3.453125,-1.896484375,-2.564453125,-2.591796875,-2.810546875],[-3.251953125,-3.099609375,-2.169921875,-2.611328125,-0.77197265625,-1.341796875,0.0283966064453125,-1.1025390625,-1.0888671875,-0.89404296875],[-4.79296875,-4.73046875,-3.796875,-4.27734375,-2.328125,-2.99609375,-1.3720703125,-2.53515625,-2.845703125,-2.642578125],[-3.70703125,-4.046875,-2.92578125,-3.61328125,-1.333984375,-2.234375,-0.673828125,-1.923828125,-2.580078125,-2.298828125],[-3.876953125,-4.25390625,-2.884765625,-3.93359375,-1.6162109375,-2.736328125,-0.89453125,-2.287109375,-3.00390625,-2.69140625],[-4.203125,-4.48828125,-2.927734375,-4.15234375,-1.8955078125,-2.896484375,-1.0205078125,-2.9375,-3.693359375,-3.31640625],[-4.82421875,-5.82421875,-3.23828125,-3.806640625,-2.279296875,-3.1953125,-1.63671875,-3.82421875,-5.06640625,-4.125],[-42.28125,-58.03125,-29.015625,-41.53125,-26.0625,-32.96875,-15.0859375,-31.6875,-34.90625,-32.625]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Token: %{x}\\u003cbr\\u003ey: %{y}\\u003cbr\\u003ecolor: %{z}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Token\"},\"tickvals\":[0,1,2,3,4,5,6,7,8,9],\"ticktext\":[\"\\u2581All\",\"\\u2581humans\",\"\\u2581are\",\"\\u2581honest\",\"\\u2581and\",\"\\u2581always\",\"\\u2581tell\",\"\\u2581the\",\"\\u2581truth\",\".\"]},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\"},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(165,0,38)\"],[0.1,\"rgb(215,48,39)\"],[0.2,\"rgb(244,109,67)\"],[0.3,\"rgb(253,174,97)\"],[0.4,\"rgb(254,224,139)\"],[0.5,\"rgb(255,255,191)\"],[0.6,\"rgb(217,239,139)\"],[0.7,\"rgb(166,217,106)\"],[0.8,\"rgb(102,189,99)\"],[0.9,\"rgb(26,152,80)\"],[1.0,\"rgb(0,104,55)\"]],\"cmin\":-3,\"cmax\":3},\"margin\":{\"t\":60},\"width\":1000,\"height\":600},                        {\"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"ea8d5373-2ad8-4e19-9c92-e0cf0bbe7a70\" class=\"plotly-graph-div\" style=\"height:600px; width:1000px;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"ea8d5373-2ad8-4e19-9c92-e0cf0bbe7a70\")) {                    Plotly.newPlot(                        \"ea8d5373-2ad8-4e19-9c92-e0cf0bbe7a70\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"z\":[[-0.0086212158203125,-0.0017242431640625,-0.0180511474609375,0.01081085205078125,-0.00418853759765625,0.0131072998046875,0.0101165771484375,0.002437591552734375,0.0201568603515625,-0.0143890380859375],[-0.01189422607421875,-0.00963592529296875,-0.021240234375,0.0004916191101074219,-0.0052337646484375,0.0215911865234375,0.0189208984375,0.02728271484375,0.033294677734375,-0.0179443359375],[0.0244903564453125,0.0099639892578125,0.00724029541015625,0.007785797119140625,0.0293121337890625,0.05548095703125,0.057220458984375,0.07794189453125,0.050018310546875,0.04180908203125],[0.08953857421875,0.0220184326171875,0.0161590576171875,0.03839111328125,0.0191650390625,0.051055908203125,0.0254669189453125,0.0552978515625,-0.0400390625,0.0128936767578125],[0.0145416259765625,-0.0196075439453125,0.0059814453125,0.0277862548828125,-0.002269744873046875,0.0129852294921875,0.042327880859375,0.06268310546875,0.0171966552734375,0.0010690689086914062],[-0.138427734375,-0.02252197265625,-0.0526123046875,0.1422119140625,0.106201171875,0.07073974609375,0.03948974609375,0.0828857421875,-0.03857421875,-0.02734375],[-0.101806640625,-0.0672607421875,-0.10986328125,0.1309814453125,0.036956787109375,0.0556640625,0.051971435546875,0.11053466796875,0.00806427001953125,-0.019805908203125],[-0.05645751953125,-0.022186279296875,-0.09271240234375,0.151123046875,0.051910400390625,0.08148193359375,0.056396484375,0.1314697265625,0.005794525146484375,-0.035888671875],[0.130126953125,0.235107421875,0.08905029296875,0.1676025390625,0.0970458984375,0.1622314453125,0.08856201171875,0.1619873046875,0.0263824462890625,0.02398681640625],[-0.3935546875,-0.0704345703125,-0.56591796875,-0.09442138671875,-0.48779296875,-0.129150390625,-0.027130126953125,0.014892578125,-0.155517578125,-0.6435546875],[-0.521484375,-0.13720703125,-0.650390625,-0.2607421875,-0.76416015625,-0.2147216796875,-0.06170654296875,-0.006256103515625,-0.359619140625,-0.99267578125],[-0.425537109375,0.1295166015625,-0.394287109375,-0.011077880859375,-0.48681640625,-0.16455078125,0.014862060546875,0.10882568359375,-0.1875,-0.841796875],[-1.0126953125,-0.14697265625,-0.77587890625,-0.390380859375,-0.76904296875,-0.44482421875,-0.349365234375,-0.21728515625,-0.53564453125,-1.169921875],[-1.1474609375,-0.666015625,-1.0556640625,-0.8310546875,-1.0029296875,-0.63671875,-0.61328125,-0.4267578125,-0.73388671875,-1.25390625],[-1.04296875,-0.8154296875,-1.1474609375,-0.55517578125,-0.77587890625,-0.45654296875,-0.443115234375,-0.334228515625,-0.4267578125,-0.89404296875],[-1.2275390625,-1.0244140625,-1.34375,-0.46484375,-0.85302734375,-0.4443359375,-0.403076171875,-0.419921875,-0.488525390625,-1.3505859375],[-1.818359375,-1.71875,-1.9033203125,-1.158203125,-1.2578125,-0.708984375,-0.65625,-0.61328125,-1.2265625,-2.13671875],[-2.33203125,-2.4375,-2.544921875,-1.7451171875,-1.955078125,-1.361328125,-1.1259765625,-1.0234375,-1.7421875,-2.82421875],[-1.3701171875,-1.51953125,-1.5419921875,-0.56396484375,-0.89501953125,-0.32861328125,-0.2032470703125,-0.13134765625,-0.6357421875,-1.7490234375],[-2.42578125,-2.484375,-2.546875,-1.234375,-1.7392578125,-0.9833984375,-0.8583984375,-0.7802734375,-1.4091796875,-2.515625],[-2.087890625,-1.9052734375,-1.9326171875,-0.5341796875,-1.291015625,-0.53369140625,-0.53369140625,-0.27587890625,-0.77978515625,-2.3671875],[-2.12109375,-2.0625,-2.14453125,-0.66015625,-1.349609375,-0.38671875,-0.5771484375,-0.330078125,-0.8330078125,-2.412109375],[-4.00390625,-3.689453125,-4.1796875,-2.134765625,-2.78125,-1.6171875,-2.0,-1.7333984375,-2.1796875,-3.873046875],[-3.22265625,-2.650390625,-3.046875,-1.24609375,-1.7021484375,-0.306396484375,-0.8359375,-0.81005859375,-1.25390625,-3.15234375],[-3.859375,-2.97265625,-3.3046875,-1.544921875,-2.19921875,-0.65478515625,-1.333984375,-1.345703125,-1.615234375,-3.669921875],[-3.67578125,-2.71875,-3.1640625,-1.333984375,-1.8974609375,-0.53076171875,-1.6552734375,-1.6103515625,-1.45703125,-3.5546875],[-4.41015625,-3.46484375,-3.9453125,-2.013671875,-2.66796875,-1.0537109375,-2.212890625,-2.513671875,-2.326171875,-4.21484375],[-4.6640625,-3.5390625,-4.22265625,-1.9638671875,-2.8515625,-1.294921875,-2.525390625,-3.1796875,-2.923828125,-4.6953125],[-4.41015625,-3.009765625,-4.05078125,-1.7587890625,-2.86328125,-1.0244140625,-2.419921875,-3.115234375,-2.82421875,-4.59765625],[-5.203125,-3.611328125,-4.83203125,-2.609375,-3.58984375,-1.71484375,-3.6484375,-4.359375,-4.03125,-5.1796875],[-5.2265625,-2.599609375,-3.171875,-1.669921875,-2.580078125,-1.013671875,-3.189453125,-4.42578125,-3.50390625,-4.78125],[-48.125,-18.828125,-31.15625,-15.8046875,-22.5625,-4.63671875,-21.375,-24.46875,-22.4375,-32.0]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Token: %{x}\\u003cbr\\u003ey: %{y}\\u003cbr\\u003ecolor: %{z}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Token\"},\"tickvals\":[0,1,2,3,4,5,6,7,8,9],\"ticktext\":[\"\\u2581All\",\"\\u2581humans\",\"\\u2581are\",\"\\u2581honest\",\"\\u2581and\",\"\\u2581always\",\"\\u2581tell\",\"\\u2581the\",\"\\u2581truth\",\".\"]},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\"},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(165,0,38)\"],[0.1,\"rgb(215,48,39)\"],[0.2,\"rgb(244,109,67)\"],[0.3,\"rgb(253,174,97)\"],[0.4,\"rgb(254,224,139)\"],[0.5,\"rgb(255,255,191)\"],[0.6,\"rgb(217,239,139)\"],[0.7,\"rgb(166,217,106)\"],[0.8,\"rgb(102,189,99)\"],[0.9,\"rgb(26,152,80)\"],[1.0,\"rgb(0,104,55)\"]],\"cmin\":-3,\"cmax\":3},\"margin\":{\"t\":60},\"width\":1000,\"height\":600},                        {\"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('435982b5-4ef7-425e-b8b4-343ae8a75879');\n",
+       "var gd = document.getElementById('ea8d5373-2ad8-4e19-9c92-e0cf0bbe7a70');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -1666,10 +1691,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "379fe7a4-3698-4594-a3d3-b8d74491c58b",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING - It is generally recommended to use detect_by_classifier instead of detect_by_layer_avg. To do so, use self.tune() to train a classifier and then pass the classifier to detect.\n"
+     ]
+    },
     {
      "data": {
       "application/vnd.plotly.v1+json": {
@@ -1686,16 +1718,16 @@
          "yaxis": "y",
          "z": [
           [
-           -1.5048828125,
-           -1.416015625,
-           -1.177734375,
-           -1.474609375,
-           -0.6123046875,
-           -1.02734375,
-           -0.456298828125,
-           -0.416748046875,
-           -0.299560546875,
-           -0.68701171875
+           -1.56640625,
+           -1.3251953125,
+           -1.623046875,
+           -0.759765625,
+           -1.171875,
+           -0.6005859375,
+           -0.56005859375,
+           -0.440673828125,
+           -0.83544921875,
+           -1.787109375
           ]
          ]
         }
@@ -1703,8 +1735,8 @@
        "layout": {
         "autosize": true,
         "coloraxis": {
-         "cmax": 1.5048828125,
-         "cmin": -1.5048828125,
+         "cmax": 1.787109375,
+         "cmin": -1.787109375,
          "colorscale": [
           [
            0,
@@ -2621,8 +2653,8 @@
          "autorange": true,
          "constrain": "domain",
          "domain": [
-          0.31431818181818183,
-          0.6856818181818182
+          0.3463636363636364,
+          0.6536363636363636
          ],
          "range": [
           0.5,
@@ -2631,11 +2663,10 @@
         }
        }
       },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+EAAAFoCAYAAAA4mfrfAAAAAXNSR0IArs4c6QAAIABJREFUeF7s3Wd8FFXbx/ErhI6IBQsWLNyKDbFhV1QURBBFEAUBKVKkN6kiHaQ36VIEkSpIVVQQReyCClZU1AcLYkMQlJbnc53NbDbJhmwyZ2Y3u795Ydzs7JmZ70zY+c9pSSkpKSnCggACCCCAAAIIIIAAAggggAACngskEcI9N2YDCCCAAAIIIIAAAggggAACCBgBQjgXAgIIIIAAAggggAACCCCAAAI+CRDCfYJmMwgggAACCCCAAAIIIIAAAggQwrkGEEAAAQQQQAABBBBAAAEEEPBJgBDuEzSbQQABBBBAAAEEEEAAAQQQQIAQzjWAAAIIIIAAAggggAACCCCAgE8ChHCfoNkMAggggAACCCCAAAIIIIAAAoRwrgEEEEAAAQQQQAABBBBAAAEEfBIghPsEzWYQQAABBBBAAAEEEEAAAQQQIIRzDSCAAAIIIIAAAggggAACCCDgkwAh3CdoNoMAAggggAACCCCAAAIIIIAAIZxrAAEEEEAAAQQQQAABBBBAAAGfBAjhPkGzGQQQQAABBBBAAAEEEEAAAQQI4VwDCCCAAAIIIIAAAggggAACCPgkQAj3CZrNIIAAAggggAACCCCAAAIIIEAI5xpAAAEEEEAAAQQQQAABBBBAwCcBQrhP0GwGAQQQQAABBBBAAAEEEEAAAUI41wACCCCAAAIIIIAAAggggAACPgkQwn2CZjMIIIAAAggggAACCCCAAAIIEMK5BhBAAAEEEEAAAQQQQAABBBDwSYAQ7hM0m0EAAQQQQAABBBBAAAEEEECAEM41gAACCCCAAAIIIIAAAggggIBPAoRwn6DZDAIIIIAAAggggAACCCCAAAKEcK4BBBBAAAEEEEAAAQQQQAABBHwSIIT7BM1mEEAAAQQQQAABBBBAAAEEECCEcw0ggAACCCCAAAIIIIAAAggg4JMAIdwnaDaDAAIIIIAAAggggAACCCCAACGcawABBBBAAAEEEEAAAQQQQAABnwQI4T5BsxkEEEAAAQQQQAABBBBAAAEECOFcAwgggAACCCCAAAIIIIAAAgj4JEAI9wmazSCAAAIIIIAAAggggAACCCBACOcaQAABBBBAAAEEEEAAAQQQQMAnAUK4T9BsBgEEEEAAAQQQQAABBBBAAAFCONcAAggggAACCCCAAAIIIIAAAj4JEMJ9gmYzCCCAAAIIIIAAAggggAACCBDCuQYQQAABBBBAAAEEEEAAAQQQ8EmAEO4TNJtBAAEEEEAAAQQQQAABBBBAgBDONYAAAggggAACCCCAAAIIIICATwKEcJ+g2QwCCCCAAAIIIIAAAggggAAChHCuAQQQQAABBBBAAAEEEEAAAQR8EiCE+wTNZhBAAAEEEEAAAQQQQAABBBAghHMNIIAAAggggAACCCCAAAIIIOCTACHcJ2g2gwACCCCAAAIIIIAAAggggAAhnGsAAQQQQAABBBBAAAEEEEAAAZ8ECOE+QbMZBBBAAAEEEEAAAQQQQAABBAjhXAMIIIAAAggggAACCCCAAAII+CRACPcJms0ggAACCCCAAAIIIIAAAgggQAjnGkAAAQQQQAABBBBAAAEEEEDAJwFCuE/QbAYBBBBAAAEEEEAAAQQQQAABQjjXAAIIIIAAAggggAACCCCAAAI+CRDCfYJmMwgggAACCCCAAAIIIIAAAggQwrkGEEAAAQQQQAABBBBAAAEEEPBJgBDuEzSbQQABBBBAAAEEEEAAAQQQQIAQzjWAAAIIIIAAAggggAACCCCAgE8ChHCfoNkMAggggAACCCCAAAIIIIAAAoRwrgEEEEAAAQQQQAABBBBAAAEEfBIghPsEzWYQQAABBBBAAAEEEEAAAQQQIIRzDSCAAAIIIIAAAggggAACCCDgkwAh3CdoNoMAAggggAACCCCAAAIIIIAAIZxrAAEEEEAAAQQQQAABBBBAAAGfBAjhPkGzGQQQQAABBBBAAAEEEEAAAQQI4VwDCCCAAAIIIIAAAggggAACCPgkQAj3CZrNIIAAAggggAACCCCAAAIIIEAI5xpAAAEEEEAAAQQQQAABBBBAwCcBQrhP0GwGAQQQQAABBBBAAAEEEEAAAUI41wACCCCAAAIIIIAAAggggAACPgkQwn2CZjMIIIAAAggggAACCCCAAAIIEMK5BhBAAAEEEEAAAQQQQAABBBDwSYAQ7hM0m0EAAQQQQAABBBBAAAEEEECAEM41gAACCCCAAAIIIIAAAgggYF0gX+vrJCUlRZKSknz9mTLxHevHYrNAQrhNTcpCAAEEEEAAAQQQQAABBBAwAsltrhdJEpEUSf/T8cn4e+e1y/cPj38rps8AITymTw87hwACCCCAAAIIIIAAAgjkTYEC7W+UFEkJyeFJvrw+NHZjTIMRwmP69LBzCCCAAAIIIIAAAggggEDeFCjQ8ca0AJ6UJJKiVd2pFeNOE/WQ17bePzD6zZgGI4TH9Olh5xBAAAEEEEAAAQQQQACBvClQqMvNgeB9lD7hXrx/YOSGmAYjhMf06WHnEEAAAQQQQAABBBBAAIG8KVC4a8Wo7Pi/w16PynYj3SghPFIp1kMAAQQQQAABBBBAAAEEEIhYoGiPW1NHRXcqxJ1R0r19vf/J9RHvYzRWJIRHQ51tIoAAAggggAACCCCAAAJxLlCs160hR+gMk+78yrvX/wx6LaZlCeExfXrYOQQQQAABBBBAAAEEEEAgbwoc80SlYJ9wp++3Hz/3DlgX02CE8Jg+PewcAggggAACCCCAAAIIIJA3BYr3vT3Tjmes/864go33/+77akyDEcJj+vSwcwgggAACCCCAAAIIIIBA3hQoMaBy+D7hGacpS529LCnMtGUpKSk6uHpqBXpqn/JsPv/3E6/ENBghPKZPDzuHAAIIIIAAAggggAACCORNgeMGVQ7suE4Prkna/I/3r//q9XJMgxHCY/r0sHMIIIAAAggggAACCCCAQN4UOGHInZIiKZIkSb7+/LPHmpgGI4TH9Olh5xBAAAEEEEAAAQQQQACBvClwwtCqIU3JM4zRFlIhnpISqChP99PF+793fTGmwQjhMX162DkEEEAAAQQQQAABBBBAIG8KlBxRLdgnPHAEafOEe/n698dWxzQYITymTw87hwACCCCAAAIIIIAAAgjkTYGTRlUL2XHv5gV3Ar3T53xXp1UxDUYIj+nTw84hgAACCCCAAAIIIIAAAnlT4JSxd6fWhDs14P78/LXDypgGI4TH9Olh5xBAAAEEEEAAAQQQQACBvClw6vgaUdnxX9ouj8p2I90oITxSKdZDAAEEEEAAAQQQQAABBBCIWKDUxHtTR1sLjLLmzAMuTsv04Ghsdt//ufWyiPcxGisSwqOhzjYRQAABBBBAAAEEEEAAgTgXOG3yvcEjdKYpc37h5eufWr4Q07KE8Jg+PewcAggggAACCCCAAAIIIJA3Bc6cep8z0VimnykpKaZmPDCYWuafbt7/v+ZLYxqMEB7Tp4edQwABBBBAAAEEEEAAAQTypsA5T2sIzypop9WJhw/iuX9/+yPPxzQYITymTw87hwACCCCAAAIIIIAAAgjkTYHzZtSOyujoXzclhOfNK4a9RgABBBBAAAEEEEAAAQQQyLXABTNrBz+bcVC24OvUNWy+/0WjxbneZz8+SE24H8psAwEEEEAAAQQQQAABBBBIMIFLZtdJHR09Kd3PtMCd/veSOlq62/e3PrwopqUJ4TF9etg5BBBAAAEEEEAAAQQQQCBvClw2p05UdvyjBgujst1IN0oIj1SK9RBAAAEEEEAAAQQQQAABBCIWuGrug5IiKSHTgicF+ogHx0RP8uT9Dx9aEPE+RmNFQng01NkmAggggAACCCCAAAIIIBDnAtfMezDLsdGznpwsq0nLIv/9O3Xnx7QsITymTw87hwACCCCAAAIIIIAAAgjkTYEbF9SVlBQx84EH5v0O20Xc+vsbH5wXFuzIkRSzH8nJ+aIKSgiPKj8bRwABBBBAAAEEEEAAAQTiU6DiwnqBacKdJSWLacMtv//6/c9lAtXw3XfkLPP7fl0aRxWcEB5VfjaOAAIIIIAAAggggAACCMSnQKXnHwrOEy6pATxQMx7sFO7J++tqz00Humb9ezJwzBz54689Urt6RUJ4fF5uHBUCCCCAAAIIIIAAAgggkNgCVZbUNwBOBbijYV47QdyD99fc92w6+H37/5O/9/4jo6cuksKFChLCE/uy5OgRQAABBBBAAAEEEEAAgfgUqPZCg0AAN33BdVR0HQ3d+9er750TFrT/6Nly+PBhQnh8Xm4cFQIIIIAAAggggAACCCCQ2AI1ljeMCsDyGrMJ4VGRZ6MIIIAAAggggAACCCCAAAJRE6i18mFTAx5oex4Yoy3tdWrNuAfvL7mbEB61k86GEUAAAQQQQAABBBBAAAEEoiNQZ3WjwIYzdQpPC+ZevL/wrsAo6BkXmqNH5zpgqwgggAACCCCAAAIIIIAAAj4I1HupcXD088A84c584d7+nFc1fQg/fPiIHDlyRAaOnSOHDh2Wvp0bSXJysuTLFzp/mg8gqZtgijL/rNkSAggggAACCCCAAAIIIJAwAg3WNE4N3qlN0cUJ4t6+nl15Rjrjhctfk36jnkn3uwFdm8h9d90clXNBCI8KOxtFAAEEEEAAAQQQQAABBOJboMmrTUNGRT9KTbgZNd3e+zPvSB/CY02ZEB5rZ4T9QQABBBBAAAEEEEAAAQTiQKDZ2kdSj8LpFJ7xp3OQdt+fVunpmNYjhMf06WHnEEAAAQQQQAABBBBAAIG8KfDoa82i0id88m2E8Lx5xbDXCCCAAAIIIIAAAggggAACuRZos15rws3EZL7+fOqWabneZz8+SE24H8psAwEEEEAAAQQQQAABBBBIMIH2bzTTicED84QHc7j3r8dWpCY8wS41DhcBBBBAAAEEEEAAAQQQQKDThmZRQRh1EzXhUYFnowgggAACCCCAAAIIIIAAAtET6LqxeVT6hA+/kRAevbPOlhFAAAEEEEAAAQQQQAABBKIi0P2t5qZHuLPYHQM9rYV7xvKHXD81Kscb6UbpEx6pFOshgAACCCCAAAIIIIAAAghELPD4Oy2C84SbyJyU5MvrQdcRwiM+SayIAAIIIIAAAggggAACCCAQHwJ93mmROji694OxhQ7+1u+aKTENSE14TJ8edg4BBBBAAAEEEEAAAQQQyJsCA95rkfWg6BknLcuY0128/8TVhPC8ecWw1wgggAACCCCAAAIIIIAAArkWGPR+i+As4U4hWc0abvP9nhUI4bk+aXwQAQQQQAABBBBAAAEEEEAgbwoM/bBlVEZH734VITxvXjHsNQIIIIAAAggggAACCCCAQK4FRmxqmevPuvlglysmu/m455+lT7jnxGwAAQQQQAABBBBAAAEEEEg8gdEfPSqS4nT29u9nx8sJ4TF5te3Zu08OHT4sx5coHpP7x04hgAACCCCAAAIIIIAAAnlZYNzHj0Zl99uVnxSV7Ua60YSrCd+3/1/pNnCKrNu42RhdelEZGT+wnZQ8oURYs7UbNkm73uMyvbfp5WlSqGCBSJ1ZDwEEEEAAAQQQQAABBBBIKIGJW1ql9gl3KsRT5wlP8vZ160sJ4TF1oT393CpZtGK9zBnfS4oULiiPdh8t55QuJQO6Ngm7n69u+FB6DJ4mi6f1S/d+6dNPlqQkHduPBQEEEEAAAQQQQAABBBBAIKPAlK2BmvBAi3RnXHTvX7e4hBAeU1dj7WZ9pMotFaTZQ9XNfq1Z/5506jtRtr42M2yo1hDeb+Qs2fDC+Jg6DnYGAQQQQAABBBBAAAEEEIhlgac/bSUpkiJJkpT+Z1JqjXjG3zuvXb7f7GJCeExdFxWqtpSB3ZqaIK7LZ199J/c37ytvrZggJYoXy7SvGsLb9x4v91S5QQoVKihXlS9rPps/OTmmjoudQQABBBBAAAEEEEAAAQRiSWDmZ60kOFF4VhOEe/D7xhdOjCWGTPsSN33Cf/rlN1m19p0ssevXqiyFCxWQS25tLBOHdJSK15U3637z3Y9So1EveXXBSCl1yomZPr/li+2mtlwD+k87f5eFy1+TejUrSa/2DWL6xLJzCCCAAAIIIIAAAggggEA0BeZ80TptnnCnRtwZLT3ktTZVD9aYW3i/ISHcn9P+/Y6dMn/Zuiw31rZJTSlapLBoTfig7o9I5YpXmXWzqwnPWOCS1W9I72Ez5OO1001t+DuPx24z9XxJSVK4YLK58PcfOOzPicjlVgoXyuUHffpYkUL5Zf9/h3zaWu42c8KJ+XL3QZ8+lS9JpGD+fPLvwSM+bTF3m9m5M7b3r0D+fKZf1aHDsb2fF9x7Ru5OgE+fKlwoWf47cNhYxvKy77PfYnb39IapUIF88m+Mf78Uvbp0zBrqjuVPzifaTfLgodj+m5b8sd0CsHCBZDl46LAcjvG/aSlSOGavR62MLFIoWfb9F9v3jEe2/xKzhoG/6SRJzpck/8X4/U6J62r74jj3y9bB7ei/daHfu2k9xAOr2Hz/obITfDm+3G4kbmrCIwXQPuF33nq1PFKvmvlIdn3CM5a74d0t0rLbSPlwzVQpXKigPJdUNtJNs95RBEocC49bgfPLxvYNktvj8+vzH30U2zcffjm43U6tede7LYLPi8iu+Z/j4FLgpE43uyyBj5ub40IFgbAhcOJxNkpJ6DIOvbopoY/f1sEXaPqcraKOWs6CbW1CpglPMWNwaQVh+p9OALf3/oPnE8J9OcGRbmTa3JWyeOXrZnT0okUKSctuo9KNjj5r4Uui05LNGd/TFPnc0rVStsyZctH5Z8vuPXvlsf6TpUD+ZJkxulvgfUJ4pPRHXY8Q7p6REO7eUEsghNtxJITbcSSEu3ckhLs3JITbMTSlEMJdYxLCXROaAvwK4Yu2tQ0kbNFmKmF+hjQ9t/n+/f/LPMW0HTk7pSRcTfg/+/6VLv0nyRvvfGwELyl7jowf1F5OLhl4Mjl84nxZuGK9vP/iZPN61JSFMn3e6qC2zis+vHdLOaPUSYRwO9egKYUQ7h6TEO7ekBBux1BLIYTbsSSEu3ckhLs3JITbMSSE23EkhNtx9CuEL/mmQ1TmCa/1v7F2oDwqJeFCuOO4e88/cvDgISl5Qolsaf/974Ds+v0vKV6sqBxX4ph061MTni1fRCsQwiNiOupKhHD3hoRwO4aEcHuOhHD3loRw94aEcDuGhHA7joRwO45+hfAXvu1oZ4dzWMq9547O4Sf8XT1hQ7gtZkK4HUlCuHtHQrh7Q0K4HUNCuD1HQrh7S0K4e0NCuB1DQrgdR0K4HUe/QviK7Z3DzxOe1fzgln5f45xRdqA8KoUQ7hKWEO4SMPXjhHD3joRw94aEcDuGhHB7joRw95aEcPeGhHA7hoRwO46EcDuOfoXwVd91sbPDOSyl2tkjcvgJf1cnhLv0JoS7BCSE2wEUEUK4HUoGZrPjSJ9wO46EcPeOhHD3hoRwO4aEcDuOhHA7jn6F8Jd+6BroE+7UcDujo3v8uupZw+1AeVQKIdwlLCHcJSAh3A4gIdyaIyHcDiUh3I4jIdy9IyHcvSEh3I4hIdyOIyHcjqNfIfzlHwIzSgWWTDODp46abv/9yqWH2oHyqBRCuEtYQrhLQEK4HUBCuDVHQrgdSkK4HUdCuHtHQrh7Q0K4HUNCuB1HQrgdR79C+NodPULmCXfmA/f+5+1nDrED5VEphHCXsIRwl4CEcDuAhHBrjoRwO5SEcDuOhHD3joRw94aEcDuGhHA7joRwO45+hfDXdvRMTdzhpwlPS+h237/19EF2oDwqhRDuEpYQ7hKQEG4HkBBuzZEQboeSEG7HkRDu3pEQ7t6QEG7HkBBux5EQbsfRrxD+xk+9U+cJT8r00wngps+401c85Keb9yuePtAOlEelEMJdwhLCXQISwu0AEsKtORLC7VASwu04EsLdOxLC3RsSwu0YEsLtOBLC7Tj6FcLf/PmJwA6npFWI+/H6xlL97UB5VAoh3CUsIdwlICHcDiAh3JojIdwOJSHcjiMh3L0jIdy9ISHcjiEh3I4jIdyOo18h/O1f+krGGm0/Xl9Xqp8dKI9KIYS7hCWEuwQkhNsBJIRbcySE26EkhNtxJIS7dySEuzckhNsxJITbcSSE23H0K4S/u7NfcEx0Z2x0P35efUofO1AelUIIdwlLCHcJSAi3A0gIt+ZICLdDSQi340gId+9ICHdvSAi3Y0gIt+NICLfj6FcI/+DXAanTkGn0DixOH/C0I0lJHZXN3vsVTkltBm+Hy3ophHCXpIRwl4CEcDuAhHBrjoRwO5SEcDuOhHD3joRw94aEcDuGhHA7joRwO45+hfBNuwal1oSnSJL5v9SgLYHXTvxOSX1t6/3LT+plB8qjUgjhLmEJ4S4BCeF2AAnh1hwJ4XYoCeF2HAnh7h0J4e4NCeF2DAnhdhwJ4XYc/QrhH/+m83WnjX4uSUnBPuKmb3hqRHdGR7f1fvmSPe1AeVQKIdwlLCHcJSAh3A4gIdyaIyHcDiUh3I4jIdy9IyHcvSEh3I4hIdyOIyHcjqNfIXzL70+G1H+bQdJ9eX3Jid3tQHlUCiHcJSwh3CUgIdwOICHcmiMh3A4lIdyOIyHcvSMh3L0hIdyOISHcjiMh3I6jXyH88z+HmT7gTg13xhpvr15fdEI3O1AelUIIdwlLCHcJSAi3A0gIt+ZICLdDSQi340gId+9ICHdvSAi3Y0gIt+NICLfj6FcI//LP4WaHTQ24Myy6cwghr22/X/b4x+xAeVQKIdwlLCHcJSAh3A4gIdyaIyHcDiUh3I4jIdy9IyHcvSEh3I4hIdyOIyHcjqNfIXzb7lHp+4Bn7BPu0evzjutsB8qjUgjhLmEJ4S4BCeF2AAnh1hwJ4XYoCeF2HAnh7h0J4e4NCeF2DAnhdhwJ4XYc/Qrh3+weY2eHc1hKmRIdcvgJf1cnhLv0JoS7BCSE2wEkhFtzJITboSSE23EkhLt3JIS7NySE2zEkhNtxJITbcfQrhG//e7w404/5+fPcY9vZgfKoFEK4S1hCuEtAQrgdQEK4NUdCuB1KQrgdR0K4e0dCuHtDQrgdQ0K4HUdCuB1Hv0L493smmB32a1R0R+es4q3tQHlUCiHcJSwh3CUgIdwOICHcmiMh3A4lIdyOIyHcvSMh3L0hIdyOISHcjiMh3I6jXyH8//ZONqOjO6Og+/WzdPFH7UB5VAoh3CUsIdwlICHcDiAh3JojIdwOJSHcjiMh3L0jIdy9ISHcjiEh3I4jIdyOo18hfMfeqc7sZJl/hoyaHjKLWdp6Lt4/vVhzO1AelUIIdwlLCHcJSAi3A0gIt+ZICLdDSQi340gId+9ICHdvSAi3Y0gIt+NICLfj6FcI/3nf9EBNuCQFpynz4/VpxR6xA+VRKYRwl7CEcJeAhHA7gIRwa46EcDuUhHA7joRw946EcPeGhHA7hoRwO46EcDuOfoXwX/bN1BnCQ3qFO73Dvf15atFGdqA8KoUQ7hKWEO4SkBBuB5AQbs2REG6HkhBux5EQ7t6REO7ekBBux5AQbseREG7H0a8Qvmv/bAltau7k8bS+4emnEbf1/slFG9qB8qgUQrhLWEK4S0BCuB1AQrg1R0K4HUpCuB1HQrh7R0K4e0NCuB1DQrgdR0K4HUe/Qvhv++eGrwh3DiOrCnGX75cs/JAdKI9KIYS7hCWEuwQkhNsBJIRbcySE26EkhNtxJIS7dySEuzckhNsxJITbcSSE23H0K4T/8d/89FXdSUnB0dLTVZEnJQXXc0ZTd/P+iYXr2oHyqBRCuEtYQrhLQEK4HUBCuDVHQrgdSkK4HUdCuHtHQrh7Q0K4HUNCuB1HQrgdR79C+F//LbSzwzks5bhCdXL4CX9XJ4S79CaEuwQkhNsBJIRbcySE26EkhNtxJIS7dySEuzckhNsxJITbcSSE23H0K4T/feB5SRFndHT/fpYoWNsOlEelEMJdwhLCXQISwu0AEsKtORLC7VASwu04EsLdOxLC3RsSwu0YEsLtOBLC7Tj6FcL3HFxqxlrLanG6hNt+/5gCNe1AeVQKITxC2D1798mhw4fl+BLF032CEB4hYDarlTjWTjmJXMr5ZZMT+fCtHTsh3A4lIdyOIyHcvSMh3L0hIdyOISHcjiMh3I6jXyF836HlwT7gTl9vP34WK3BPWKjf/tgtRYsUlqJFCtmBzGUphPBs4Pbt/1e6DZwi6zZuNmteelEZGT+wnZQ8oYR5TQjP5ZWX4WOEcPeOhHD3hloCIdyOIyHcjiMh3L0jIdy9ISHcjiEh3I4jIdyOo18hfP+hlcEddqYlc37h5esi+aung/rhx53Sstso+X7HTvP7++66WZ7o9LAUyB+dSixCeDbX8dPPrZJFK9bLnPG9pEjhgvJo99FyTulSMqBrE0K4nX8DTCmEcPeYhHD3hoRwO4ZaCiHcjiUh3L0jIdy9ISHcjiEh3I4jIdyOo18h/MCRF0MGOU+RQPAWCRkM3ZP3CyVXTQfV/LERckyxIjKoezP55dffpU6LfvJEx4Zyd+Xr7YDmsBRCeDZgtZv1kSq3VJBmDwWepqxZ/5506jtRtr4201xE1ITn8IrLYnVCuHtHQrh7Q0K4HUNCuD1HQrh7S0K4e0NCuB1DQrgdR0K4HUe/QvjBI2sk/EThWU0Qbuf3BfJVDkLt3vOPXH93a3n2qV5y+SXnmd8PGjtHfvn1Dxk/qL0d0ByWQgjPBqxC1ZYysFtTE8R1+eyr7+T+5n3lrRUTpETxYoTwHF5wWa1OCHcPSQh3b0gIt2NICLfnSAh3b0kId29ICLdjSAi340gIt+PoVwg/krLW9Al3RmdLksA84ea1qREPeW3iup33k/PdHoT65rsfpUajXrL++TFy0onHmd/PWfyyLFuzURZP62cHNIelEMKPAqYXyCW3NpaJQzpKxevKmzWdk/jqgpFS6pQTCeE5vOAwspa7AAAgAElEQVQI4ZbAwhRDCLdjS59wO440R7fjSAh370gId29ICLdjSAi340gIt+PoVwhPkdcCO5xxGHSnTbpzOJbfT5Jbg1Cbt26T+m0GBStR9Y2FK9bL5NnLZN2i0XZAc1gKITwbMK0JH9T9Ealc8SqzJjXhObzCIlydmvAIoY6yGiHcvaGWQAi340gIt+NICHfvSAh3b0gIt2NICLfjSAi34+hXCBcN4Vl3As+qc7iF398WhHIqUV9fMjY4uDY14XauI89K0T7hd956tTxSr5rZBn3CvaEmhLt3JYS7NySE2zHUUgjhdiwJ4e4dCeHuDQnhdgwJ4XYcCeF2HH0L4YdfDTZFD7vnXk0UHtIcPVyf8AGjZ8uvv/1Jn3A7l5P9UqbNXSmLV75uRkfX+eR0aHtGR7fvTAh3b0oId29ICLdjSAi350gId29JCHdvSAi3Y0gIt+NICLfj6F8IfzkwT3haJ3B/Xuevkg7qkS7D5dhjipkWzoyObuca8rSUf/b9K136T5I33vnYbOeSsueYJyYnlwx06md0dDv8hHD3joRw94aEcDuGhHB7joRw95aEcPeGhHA7hoRwO46EcDuOvoXwgy8GdjhTn+/UQdOdw7H9foH0U5Rt/+FnU5m64+ddZov33nmj9O3cSAoUyG8HNIel0Cc8QjBtxnDw4KFgPwLnY4TwCAGzWY0Q7t6REO7ekBBux5AQbs+REO7ekhDu3pAQbseQEG7HkRBux9G3EP7fKkmRQE24rz8LBaaXzrjs3PWnmS+8WNHCdiBzWQohPJdwhHCXcBk+Tgh370kId29ICLdjSAi350gId29JCHdvSAi3Y0gIt+NICLfj6FsI3788GtOEixSuYQfKo1II4S5hqQl3CZj6cUK4e0dCuHtDQrgdQ0K4PUdCuHtLQrh7Q0K4HUNCuB1HQrgdR99C+L4XAn3Ak5wW6YF5wD1/XaymHSiPSiGEu4QlhLsEJITbARQRQrgdSqYos+PI6Oh2HAnh7h0J4e4NCeF2DAnhdhwJ4XYcfQvhexebzt+mKbpJ3oHO316/lmNq2YHyqBRCuEtYQrhLQEK4HUBCuDVHQrgdSkK4HUdCuHtHQrh7Q0K4HUNCuB1HQrgdR99C+J6FwTHZMk8XHgjmzphsVt8/to4dKI9KIYS7hCWEuwQkhNsBJIRbcySE26EkhNtxJIS7dySEuzckhNsxJITbcSSE23H0K4Sn7J7nTE7m608pUdcOlEelEMJdwhLCXQISwu0AEsKtORLC7VASwu04EsLdOxLC3RsSwu0YEsLtOBLC7Tj6FcLlr7mpfcCdvuA+/Ty+vh0oj0ohhLuEJYS7BCSE2wEkhFtzJITboSSE23EkhLt3JIS7NySE2zEkhNtxJITbcfQrhKf8MTu4w0mp04U7v/DyddIJDe1AeVQKIdwlLCHcJSAh3A4gIdyaIyHcDiUh3I4jIdy9IyHcvSEh3I4hIdyOIyHcjqNfIVx+nxWdmvCSje1AeVQKIdwlLCHcJSAh3A4gIdyaIyHcDiUh3I4jIdy9IyHcvSEh3I4hIdyOIyHcjqNfITxl13Q7O5zDUpJOaprDT/i7OiHcpTch3CUgIdwOICHcmiMh3A4lIdyOIyHcvSMh3L0hIdyOISHcjiMh3I6jXyFcfp0WnZrwU5rbgfKoFEK4S1hCuEtAQrgdQEK4NUdCuB1KQrgdR0K4e0dCuHtDQrgdQ0K4HUdCuB1Hv0J4yi+Ts9hhZ2KyrI7H3ftJp7a0A+VRKYRwl7CEcJeAhHA7gIRwa46EcDuUhHA7joRw946EcPeGhHA7hoRwO46EcDuOvoXwnyeITgRu5gNP0XnBRULnA3fmLbP+/mmt7UB5VAoh3CUsIdwlICHcDiAh3JojIdwOJSHcjiMh3L0jIdy9ISHcjiEh3I4jIdyOo28h/MdxIr7OEB6oQU86va0dKI9KIYS7hCWEuwQkhNsBJIRbcySE26EkhNtxJIS7dySEuzckhNsxJITbcSSE23H0K4TLjjGmBjxQBZ76w4fXSWd2tAPlUSmEcJewhHCXgIRwO4CEcGuOhHA7lIRwO46EcPeOhHD3hoRwO4aEcDuOhHA7jn6F8JQfRobssJczg5t/qYIzkSeV7mwHyqNSCOEuYQnhLgEJ4XYACeHWHAnhdigJ4XYcCeHuHQnh7g0J4XYMCeF2HAnhdhx9C+HfDTc14H63SE865zE7UB6VQgh3CUsIdwlICLcDSAi35kgIt0NJCLfjSAh370gId29ICLdjSAi340gIt+PoWwj/ZqidHc5hKUlluuXwE/6uTgh36U0IdwlICLcDSAi35kgIt0NJCLfjSAh370gId29ICLdjSAi340gIt+PoWwjfNiQ4T7gzLHpglPS0YdK9eJ3v/J52oDwqhRDuEpYQ7hKQEG4HkBBuzZEQboeSEG7HkRDu3pEQ7t6QEG7HkBBux5EQbsfRtxD+xaDUHc4477e3r5Mu6GUHyqNSCOEuYQnhLgEJ4XYACeHWHAnhdigJ4XYcCeHuHQnh7g0J4XYMCeF2HAnhdhx9C+GfDQjWhDs13n78zHfxE3agPCqFEO4SlhDuEpAQbgeQEG7NkRBuh5IQbseREO7ekRDu3pAQbseQEG7HkRBux9G3EL6lr/+jsuk84eX62IHyqBRCuEtYQrhLQEK4HUBCuDVHQrgdSkK4HUdCuHtHQrh7Q0K4HUNCuB1HQrgdR99C+Md9olMTfll/O1AelUIIdwlLCHcJSAi3A0gIt+ZICLdDSQi340gId+9ICHdvSAi3Y0gIt+NICLfj6FsI3/S42WFve4BnLj/pioF2oDwqhRDuEpYQ7hKQEG4HkBBuzZEQboeSEG7HkRDu3pEQ7t6QEG7HkBBux5EQbsfRtxD+Qa8MNeGSOkh6UhY15Hbez1dhsB0oj0ohhLuEJYS7BCSE2wEkhFtzJITboSSE23EkhLt3JIS7NySE2zEkhNtxJITbcfQrhB95t7skhdSEOzXiXv9MuuZJO1AelUIIdwlLCHcJSAi3A0gIt+ZICLdDSQi340gId+9ICHdvSAi3Y0gIt+NICLfj6FcIT3m7qzM9eMjPwDzhKSkiIdOFW30/3/XD7UB5VAoh3CUsIdwlICHcDiAh3JojIdwOJSHcjiMh3L0jIdy9ISHcjiEh3I4jIdyOo18h/MibXYI77NSIO7/w8nW+G0fYgfKoFEK4S1hCuEtAQrgdQEK4NUdCuB1KQrgdR0K4e0dCuHtDQrgdQ0K4HUdCuB1Hv0J4yhudojM6esXRdqA8KoUQ7hKWEO4SkBBuB5AQbs2REG6HkhBux5EQ7t6REO7ekBBux5AQbseREG7H0a8QfuS19jprtxkdPfyS4sn7+W4dYwfKo1II4S5hCeEuAQnhdgAJ4dYcCeF2KAnhdhwJ4e4dCeHuDQnhdgwJ4XYcCeF2HP0K4Slr20WnJvz28XagPColYUP4gQMH5c/de+XkkseZgQFyuxDCcyuX/nMljrVTTiKXcn7Z5EQ+fGvHTgi3Q0kIt+NICHfvSAh3b0gIt2NICLfjSAi34+hXCD/ycuuQHfayF7j5lyp1HHaRfJUn2IHyqJSEC+EpKSkyafZymTBzqSE94bji8tTgDlL+ojJhiddu2CTteo/L9N6ml6dJoYIFhBBu58okhLt3JIS7N9QSCOF2HAnhdhwJ4e4dCeHuDQnhdgwJ4XYcCeF2HP0K4SkvtYpOTXjVSXagPCol4UL45q3bpH6bQTJnfE8pd8G5Mm76Elm19m15dcEoyZcvc434qxs+lB6Dp8niaf3SnYLSp59satAJ4XauTEK4e0dCuHtDQrgdQy2FEG7HkhDu3pEQ7t6QEG7HkBBux5EQbsfRrxB+ZFULOzucw1LyVZuSw0/4u3rChfCRkxfK519/L0+PeMxI//rbX3Jr7Q4mZF943lmZ9DWE9xs5Sza8EL5fASHczgVLCHfvSAh3b0gIt2NICLfnSAh3b0kId29ICLdjSAi340gIt+PoVwhPWdHc1IQ7LcUD84N7/zpfjWl2oDwqJeFCeJf+k+T4EsdIr/YNgqQX39JIJg7pKBWvKx82hLfvPV7uqXKDFCpUUK4qX1aq3FJB8icH+t8Swu1cmYRw946EcPeGhHA7hoRwe46EcPeWhHD3hoRwO4aEcDuOhHA7jn6F8CMvNLWzwzksJd+903P4CX9XT7gQ3vyxEVK2TGnp3LJOULpC1ZbSt0sjqVbp2kz6W77YLmvWvycliheTn3b+LguXvyb1alYKhvjVNz7k7xnLwdZ0vLn8yfnM06ZDh7OeGCAHRXq26jHFPCvaSsHqeOjwEStleVXIGWfm86poK+Xq9ZicLynmr8Wvv47t86yG+gD5iP4nhpebe18cw3snUkD/po+kBJ7Gx/Cye90Psbt3+h2TB/6mS9S5NHYNRSRZ/3FMEjl8JLavxaQCBWLaMX9ykjGM8T9pkWOPiWnHAvmT5OCh2L4WD3/4VUwb5ktKEv2zjvW/6aL39PHF8ciSJlHpE55ca6Yvx5fbjSRcCNeacB2MrWe7+kGzo9WEZ4RdsvoN6T1shny8dnqwNjy3+HwOAQQQQAABBBBAAAEEEIhXgcMLG4WMWR7+KDOOmZ5xrdy8n1xnVkyTJlwI1z7hX37zg0wd3sWcmOz6hGc8exve3SItu42UD9dMlcKFCsb0yWXnEEAAAQQQQAABBBBAAIFoCRye93CwJlxEW1kE+oQHpoj27nX+erOjdcgRbTfhQnja6Oi9pNyF58rYpxfL6rXvBEdHn7XwJdFpyXT0dF2eW7pWypY5Uy46/2zZvWevPNZ/shTInywzRneLCJiVEEAAAQQQQAABBBBAAIFEFDj0bOo4XDoWW1IgdpvF49f568+Jae6EC+H65OWpmUtl8uzl5sQULVJYpg7vLJdfcp55PXzifFm4Yr28/+Jk83rUlIUyfd7q4Em89KIyMrx3Szmj1EkxfWLZOQQQQAABBBBAAAEEEEAgmgKHnqkvZrAGk8D9+5m/0dxoHna22064EO6I/PvfAfnjz7/l1JNPDDs/eKicrrvr97+keLGiclyJ2B5QI9szzgoIIIAAAggggAACCCCAgA8CB6fXC/YJT2uA7jRE9+5n/qbP+XB0ud9Ewobw3JPxSQQQQAABBBBAAAEEEEAAgewEDk2tmzoveCCCJ6X2CTc14x6+LtBifna7FtX3CeFR5WfjCCCAAAIIIIAAAggggEB8Chyc9IA5MKclunOUXr8u8OiCmAYlhMf06WHnEEAAAQQQQAABBBBAAIG8KXDgqTomgeto6M6o6KE/nb7itt8v2HZRTIMRwmP69ORs5z7+7BspffrJcnyJ4jn7IGsjgAACcSyw9cvtUuas06VIYaaVjOPTnCcOTadF/e2Pv8yMKywIIIBAIggcGFM7KodZsMPiqGw30o0SwiOVivH1vt7+o9zTuJecf+4ZZvo0gniMnzB2DwEEfBH47Kvv5P7mfeWayy+UCUM6EsR9UWcj4QR0kNf7mvaWXb/vNt/T5S44BygEEEAg7gUOjKyVVgMe0gfc1Hx7+LpQlyUxbUsIj+nTE/nOHT58RJ4YPkNeeOlNgnjkbKyJQJ4S+HP3Htmzd79p8cISmYAGnw5PjJcN724hiEdGxloeCixZ/Yb0HjbDTI9KEPcQmqIRQCBmBP4bVjOwLzpBuI7F5iwevy7UdWnMGITbEUJ4TJ+enO0cQTxnXpGs/cuuP+SzL7+T2268IpLVWQcBawJr1r8n6zZulkHdH5H8ycmiAbxJx6Gyb/9/snLOk1Igf7K1bcV7QQRx+2d4yxfbTR+/cheea7/wOC+RIB7nJ5jDQwCBdAL/Dbk3bF/wrPqA2/p94Z7LYvpMEMJj+vQcfefC9S0jiNs5oeo4de4KeWpG4Cla3y6N5P7qt9gpPIFKOXjwkKzbuEk++vQbOeWk4+Wmq8tJmbNPTyCB3B3qocOHpUHbwfLJZ99I1duukW6t60rzx0bIV9/ukOmjusq1V1yUu4IT+FMEcTsn/++9+6TviJmyZv37psBFU/vSv/kotFn1AQ8N4jPHdJNLytI0PTdX6Dff/Whauez87U+58tLz5YYK5ehykkPI/f8ekLc/2Cq//fm3+W6hpVUOAVk9W4F/B9TIdh0vVijce7kXxVorkxBujdLfgo7Wt4wg7u5caADq+MRTphZS+5E2rVdNKpQvKwULFnBXcIJ9+v9++lW69JskOihW6NL+kVrStG41SU7Ol2AiOTvc3Xv+keZdRqTzI4DnzDB07Xc3fy5TZi8X/akLfcRzbrnr97+kfptBsuPnXVKnxq1Su1pFuej8s8yItyyZBbLrA04Qd3fVzFr4kgyfmH4e4DJnnSZjBrSVc0uXcld4nH1aH4h/8PGXct1VF6c7sh9+/FXa9Bwj33z/U/D3rRvdKy0a1OA7Os6ugWgezr99745Kn/Ai/VZG87Cz3TYhPFui2F3haE3aCOK5P28Tn1kmE2YulY7N75cmD94l+fJxg5lTTX2yXuuR3rJn7z4Z0LWpXH35hbJt+w5Tg6a1udXvuE6G9mqR02ITbv3vd+yUu+p3M8etN0+Th3YyTdNZciYwafYy06rljFInSZvGNWXV2rfpI54zQtGHk/pQSB9iPD3isUw38zksLmFWz67pOUE8d5fC0hc3yONDp0vNqjdJ68Y1pVDBArJ45XoZ+/TzpsDF0/rJheedlbvC4/BTPYdMk2VrNsrgHs3knio3mCPU+8SH2w+RzVu3yd2Vr5czS50ksxaukX37/5Vqla6VwT2b8X0Th9dCNA5pf+9qgc163Ac8Y/lFBqyKxuFGvE1CeMRUsbkiQdzuedGmltdVbyW33XC5jB/UPl3h23/42TTBLFAgv6kBKnFsMbsbj6PSRk9dJE8/t0qWTB8gZcucaY5Mb+L1pmnFy2/JxCEdpeJ15ePoiL05lKnPrjA3lVq7ozUV2jT9yV7NuTHKAffG97eapvxa8z12QFspfkxRoWl6DgBTV3Uce7Z7SB66745gAUeOpMhHn34t69/aLOeULmVu5nlQlN6XIJ7z6+1on/jtj91S8b72JigO690yuKqOU/Bgy37mAdH4ge1plh6CqF2b6rYaYH7jBPG1GzZJu97j5LFHH5RGD9xp3tPuEy26Bro+EcTtXreJXNr+nndFpU940SEvxjQ7ITymT09kO3e0J+nUiEdm6Kzl3GiG9gHXL/zB454N9oHUdbV/87KZg8wNPUtmgRoP95QL/lc6eIOUVQDXMFS4EHM3h7uGUlJSdNwr+eb7H+XkkscHm6YTxHP2F/dAi36mSf/rS8ZKyRNKBD9MEM+Z45hpi2Xa3JXy5rLxwSkwP9/2vWgNm96wO4s+wBw3sB1N1DPwZlfjnd37OTtb8b32qxs+lPa9x8uK2UOCzc41gOvAleUvLpMugPMdk3YtZAziX3z9g2x8b4ssmTEg3YOz0K5QBPH4/lvy6+j2dQ085PF7KTrsJb83maPtEcJzxBW7KxPE7ZwbvVnXm/bLLzlPHmv1oLy3+XOZ+uxK0zxLm7Y9dN/tpl+VTgXXrmktadHgbjsbjqNSNHCXr9RUHqlXzTTpP1oNuN7Yn3XGKaZJIUtAQIPNuOlLpEjhQjL08RbBUdBDb4wyBnEN7D2GTJNWD98jpU8/BcpUAa2lLXdbY1Mzpk2oMy4E8cgvlWcWrZFhE+aZvuA1Kl8vq9e+I88tXWsKqHTTFVLllqtl9sI15oHHrDHdpcJlF0ReeIKsmV3Qzu79BGHK9jCdFkLvrpokxxQrIlkFcOffzKnDu9ByLVX148++kXqpNeI6Td7D91eRNk1Sp48KkSeIZ3sZ5miFn3f+LqVOOTFHn4mnlfd1rhKVPuHFRr0c04yE8Jg+PTnbOYJ4zrzCra1hpkXXkaI14qFLn86NTBN07R9+8NBhuez2plK7ekXp16Wx+43GSQk6dVbRIoXM0dRs8rgUK1pEZo3tnmUTdA3n1ep3Nw84Xnt+DE1YRWTBsnXSf/RsY3jL9ZeZBz1Oc379XeiNkQafQd0eMc4TZ70g2u+5V/sGUq9mpTi5otwfhl5j11VvLSedWEJWPzs0bIEaxOs+2t/U5jJYW3qixStfN+M56GjJf+3eK3c/3EP++GtPcCXtYz+wW9Ng4HZu8Ps/1kRqVbvZ/QmMwxKyC9rZvR+HJDk+JB00tW2vsebB2jHHFA1bA66Frnzlbek2aIro93edu5ndxIEODeIdmtWWZg9VD3sOCOI5vjTDfmDh8tek36hnzJguN11zqZ1C81gp/3RI7cLkc5/wYmNeiWkpQnhMn57Azq1/6yP5/Ovv5cF7bgs2A8xqtyMN4s8+1cvU9rJkFtCQvfKVt0Tnab7uqkuk+u3XyYnHHxtc0WnS9XiHBlL3XgKPwugXzEdbt8mM0d3MNTpqykKZPm+1mXZHa8bC9QGfOf9FGTF5gXRtXdc8jU/0xRlo6Ipy58uQns3MIGLhFr0xatltlJm+TGsyTjiuuBmtWpsBj+nflhFtM6B16jvBdCWZM76XXFEu/L95t93fUfbs3W8eCM2f3EfKXcB0Udoio3azPqa1jz4M0mX33//I3CWvmNYaVW+7Vm678fJ03UlmLXhJhk+an24siET/uw53/NkFbed9nZqwIf82ZiLUB0I33NPGtKLa9fvuTE3QzbW65x+p3qC7/PvfQXlj6Tj6h4uIhu/yF5UxnqFBPHSwtozYThA/ueRxMqpvazMmDkvkAjpI7b2Ne5nvaF1enDs0IVur/dP29qj0CT/mqUBrrVhdCOGxemZS90sDeOueY4J7qV/IDWrdIaedWjLLPc8uiOsAT+efe0aMH7m3u3fgwEGZPGe5LFqx3nyp1LrrZvM0OLtpyHTgNh34Rb/418wbbgJQoi8vrntXuvSfZAYP04GvdHAm/eLW2vCdu/4086trH/vQ5cNPvpKG7QabkD57fE8zsm0iLz//+ofcXqeTqVGcPrJrpiCt113xYkWC/Wz1+tWm/ItWvm6CY9O6d0nbJvdxgxTmItLRvLWvqP6tvjBzULoHarq6M5iT1qodW7yYXFz27ES+FIPHrlMa6cMJDTFvLX8q22vry2/+T+5r2ttcw9ocPdEXvenWB43vf/SFnF7qJKl04xWm240zNWN2QVz76+q4GizhBfRh0OBxc8MGG23domMV6MM3/U66/aYrE4px7z/7RR8+6qjxTujWVi19Rsw0D3hrVA6Mjh5pENfvn8IFC2R7f5RQyDk42F92/SEPtxsi9999i+mml4jLnkdvE9GJhpyacJ9+Fp+4zhW3tqbLl5TPs1mSCOGuTo/3H+49bIbol/VN15STDz/ZZm64ddEpJho9UDXLMJ3dF7z3ex7bW9CmbNqkLXTRQDhhSId0gzc572sz9bc++FS6D5pimmNqULr2yoti+yB92jsdhO3P3XtkxTND5LgSxwS3GvoFf8fNV5l+pNrP+Y13P5HZi9aYUKS1jqcf5YGST4cQ9c1o39pBY+eYwf7+d87pwf1Z9+Ymee6FtfL2B58arxF9Wpkm086iXxC6MBq1yNfbf5QPP/lSTjv1JLn68gvSPdhxRuvX1gUTBncIGuvNaoO2g0xT9A9emkptWYa/BGe6xtH92kjlileF/TvRlkPa3FIHr9Rr9PmnB4jWmiXysuHdLSYE6ff1pReVMa1WdLmhwiXyZK8WwYe3fE8HrhL9fg0317zOpKGDAepDyiq3VDAtMpxrSz/Tud9EE7S1RVC7pveZB2jf/d8vMmfxy+Zv+tGG94Tt7xzv1+brb38srXqMNof53MTesu3bHSaAaxen0X1bpwvTkQbxeDfz+vj0u0bHL0jU5e8Wt0alJrzE1PW5JtdWDA+06CvN699tptX1YiGEe6FqscxvvvtRajTqZb68xw5oJ8vWvCk6KInWMOqi/6hqLZg2Yc248AUf/kQ4Nbc66ufjHRvKP//sl4Fj55hm/1qbq02qQ0dR1ifu2rRazfUmU5tkJfqgQzrq/tS5K0xT/TvrdZXhvR+Vuypdkwlcp3V7bMBk03w1dNGBsnSe8NBm/hb/bPJcUTqHtfbpXjClj2kdoE/Onxz/nLzyxgfmWHQ0fr3+9GZz9bNPykknJnbIyXiC9UZdWwY4izZTHT+wnZQ5O/BAQ2t19W9ca4N00b99bU20/OWNxpU+o+H/ZJwWGuEGttMHQANGz5bVa981YVOv2zH92yT04EOqqAMw6Xe21mKP7tfafJfozVy/UbPM9IwZLRP9e1oHOtW/XX0AXqJ42rSf+qB26IR56S5M/f7Vh2j6YEMX/R56ZtFLMnLywkwXcGiNb577QrCww3qtdR88NVhSuADuvEkQtwBOEUcV+KtpxbT3nRpx5zcevj5ueuA7P6eLdpXUlky66L0qITyngnG0vs7jqPM5LpraVy46/2wzMNhL6941N+3f79hpjlT7d2szl5uvLZ+u2QR9yzJfCNq8X8Ph0hkDg7Vlzg2l3qRnDOLOvJnXXnmxNHmwKgFIRBauWC/9Rs4yoVBvwJ1RasP92WkA2vLFt2Yu4YMHD8vN115qRppnSRNwpsbT3+hNutZ866K13jpKv3rNe2GtDBwzJ8sHHonq6djpDfrDde6UDz7+QrQmUhetBXKaY+pr/fdQa8VDBxdr3eheadnwHs+am+X18+J8/4Try6jdSrTZb737bpe699xGc1URE3x02qflzwwOjuGi11vTTkNFp7ucO6G3GegudEnk72mntZ/+Gzd9VFcTxP/vp1/Nw13tNqcPvfUh5NPPrZIpc1aE/bvWBx+bt35tpnM8+4xT5bYbr5BiRQvn9T891/vf68mnzUwuumjlQmgrqoyFE8Rdc1PAUQT+bHxzVGrCT5i1IVfnRced+PfAATOTQKfmdQjhuVKMkw85/zjqFDCj+rYKHpU+BV619m3pMXha8HdaA6RNsO689epgHz76lgV4NGBrGNSam+5t6mUavc9CCz8AACAASURBVFenM+o/6hlZtHJ92BrxOLmcrByGPrTQL3gdfVaD+KsLR6arxbCykQQrJLQ2V5tNt2xYQ+6988ZgM81NW76SBm0Hm9pGbd7PEhBwukOsnP1kcBoip3l/uCCu/27qv6l79u4ztZV6g5/oiw4KqLXe9911k5x60gnpOJyHHM6Ug4luld3x33RvW7mjYgV5omNDs6p21dExCTIGcA2ap51SMthHPFG/p0O/S5wgrsFRp8NbOXuIGWPEWZzBK8P9XWd3XhLtfR2X5fY6nc3gdU5LtIwPJTOaOPeaOvPG2P5tw3YRSDRHjteOwO8NbrRTUA5LOXFO4CFUbpcqdR8z4+1QE55bwTj5nN5860146JeSTgml/X504Bedv1r7ROogRLporVC7R2qZQbFYRHQgKx3pVwel0yXjl7tjRBCP/GrRm6eeg6fJqrXvmJpapxYj8hISc83f//xb1m3cZPrpqZtOWeJ0f9DRp3/8ZZf5fWgfSQ2O9dsOMn1L31s9mVoeEdHQogP6VW/Ywzyc1IeUoYs2NXceUGZ385mYV2LgqJ0B1RwD7Xurc4FffdmFpnWAXnt31e9mWg9sXDae2u6jXCz6b2L5Sk3NiOY6snlWAVyL0D66aqvTualzIi8Zg/ixxxSVk0oeZ5qBZlz4u478StEWfzrmivabd5qmZ/dv4bbtO+Ss00/h7zxyZtaMQOC3h24I1IRLUmBstqTUsSA8fn3Sc2+l2zvtpqHd/cIt2tJYu/6GLoTwCE5uIqyy4d1PzLREztzUoQFcByvRaWR00SeZ2mdc+zdn1/woEdxCj1HDT+MOT5ogro59OjUKe/MTGsS1H5X2QWMJL0AQz9mVoc3M2/UeHxxgUT+tLQmG925pxncIt2iN7ZDxc2XZmo0yoGsTue8u5l/Wm8s6LfoZLu0O8f6Lk40jN+w5ux6dtbXWbPXad8yAVk4XJ61Bq1+rslS7/VrRGsjhE+eHfdiRuy3Gz6f0+gu99hp1eNL0C39mXA95tNuosE3QnVrKM0qVNNO5hRuULH6EIjuS0O8S/cTR5poniGdtqi3+ShxbLFNrqdA+4hmnqNVuJXqPqXOGsyDghcCvD+jAZv4Pj37ygvQhfO6SV4PTxWU8Tp3CNGMrQ0K4F1dDHixTg6HONagBUvua6YA4WgMeGsBDD0u/5EMHOcmDh+zJLuckiE965gWpVb1ipuaZnuxYDBeqfbq15lZHkz/5xOOl4f2V0/WLJ4hHdvKcQRZ1ACudsk1Djt74PD50hgmSGW86v/3hZ3nz3U9k1sKXzOBhofM1R7bF+F0rJ90huGGP/DrQmgq9IdfRzrWFi7PoHPT69699SvXhbqIuWqN46sknBMcZcGq6dQosnQ5Kl9CuENoiLVwfcKevbiJOnxXu2vln37+mdU9Ovkucv2t9APL6krFStEihRL0sg8et49fcWjtQaRCu21JoEJ88tJNphaUP3Rp3fNIMXrlm3ggcE/4q8gZgZ+1rs5idTGvGtYY8q9nL3L1/6uK077HcHBkhPDdqcfoZvSnqOmBy8OiyCuBxevjWDivSIG5tg3m4IO3H2OGJp2Tz1m3Bo9CbnnED2poBxJwlJzdPeZjD1a4/0KKf/PX3XlPz5QwapE18G7UfYpqtht6sq2eXfpPM6Ojq/WTP5qL99FjSBHJyzTk37DNHdzfTlyXykt1DNcdG//a1b+5zS18Nzsah72XVlSfeTX/65Te548EugaA9MTC4mvb11qmwtCvOtVcEpqzU67J5lxGma5g+vBjSs3lwaiJ9mD593iozGriO9zCo+yPxzpbu+HSapjnPvyzNHqoenFZRa27HPr1YFk7pa0bWz8nftYbKk086/qgDjiUUsIi57vS6jCSI6yC0The9OeN7idYEsiDghcDPNTPPnuPFdjKWWWrpu7najP47lHIkxXR30/F5dCagAgXy56qso32IKcqsk3pXoI6KXqVuF3NDlKjzX0aiq7U5OmCYzq+846dfpXLFCtKx+f3p5mgkiGcvqTfhdVr0NdebjtB9123XymsbN0n/0bPNh50n6U5JObl5yn7r8bWGXm8312xnasCdcRqy6i/6738HpHChgmYWhHVvfig3X3sZ81dncTnk5JrT6zl06sH4usIiO5pIH6qFlqbGG9/bKvNeeNWMOq9TYnZqUSeyDcbZWqE1idqSRWsRQwO4c7jOjBoa0HXgPx2voFiRwrL2zQ9NaL/pmnIyul/bhPu71u+OBcvWSdXbrpEnezWXF158M+z81Tn5u46zS8zK4WQXxLXboram1AHbdAT6gd0eMXOssyDglcBPNa5OrfFOq/M2fcSTnJrutJ9OnbiN909f8X6uDqlT34myZv176T7rxQNoQniuTk/0PuRMU9Tq4XuCzd+itzext2UNMH1HBuZj1RrEwoUKmAGFdLRpvVnSn85CEM/6/OlAdk06DTM14FOHdwkOVqHNMTv1nRD8YFZBfP+//8nIPq0Y3CVVyhnZ3PE62oBNj3QZLp2a32+mI2QJCGhz/fVvfWz+/8ZryokO3OQs3LBHdpXk9KFaxlK1Fvf2BzrJnr375c1l44PTO0a29fhZS/sUDh73rDkgfTjZqM6dYQ9Ov4tGTVkkc5e8Enxfv5Oa168uTR68KzgqevzIZH8k2k1OWwls/XK7mVdef2Y1fzV/19l7Hm2N7IK4ftZ54OtuS3wagewFdlRLm9HFw2nBzY6Eln/Gqg+y37korkEIjyJ+bjatA7JVvK+9+ejaRaPS3Yzmprx4+ozeJHbpr0+v3pfGD1aV1o1qSv7kfNJ7+AwTyrVGYva4nlkGcVoXpF0NE59ZJhNmLjUDtWjTQV10ZO66rQaYJpa1qlUUnW9dl3BBXJvxeNF0J69erxq6b7ynrWnB8lCt28NOWaTH9uMvv0nlB7uYmqIRTzyaVw/X6n7rlIKPDZgULFP72Y7p31auvPT84O+4YT86eW4fqmUs1ZlGb3jvR+WuStFpXmj14spFYTrwmo7H4izZjTb934GDZiT/Q4cOy6UXnpvw/y5qEK/Z5HHTwiq7/tz8XR/9AtX7msvLnZfunib0E+9s+kyadhpmfsXUlrn4Y+cj1gT+784rg72+nRrujDXeXrw+86VN1o7Bi4II4V6oelzm5NnLZfyMJaaJtc7dyhIQcFy0ZkJrKHTZ8fMuqdmkt/l/rU3LKoj3HTFTenVokPCDsDnX0vxl68wo+y/NHWZqs//eu0+q1e9mmvNq32UdBMcZsd/Ypw7ywrWYtYBOkafN/7QfXsY+4Pop/WJq1WOMvPHOx7JgSh9TU5Toy9PPrZLRUxcZM32wpnMrT5mzIvD3nuGa44Y966vFzUO10FJ11O/bH+gsV5Q7X+aM75mQl6cGag2Sv+76M+JpnxISKouD1gcY+iDDWZym6fmTk8N+IvTv+vJLzjPXHaPJpz0UD3dPEwpJEOevLxYEvr/j8iwHX3P2L6vB2dy8X/qVzbFw+FnuAyE8pk9P+J37a/deueGeNiZQrl04ii8kEdGRpO9u2MPMrzx/8hNm0BcNjg+27Cc6xdPzTw+QRSteE70Zze5LKw9eEp7ssvZrPLnkcabsoRPmyexFa2TF7CFybulSwe2F1grNm9hbLr2ojCf7Eg+Fbvliu7kejWevFlL9Dp2yI22ZOf9FGTF5gTSoXVm6t6kXD4fs6hicGvDQ/rM6ivL9zfsEp9E6WhDPOA2Pq53J4x+2+VCtZbeRclyJ4mawwERfQvuIZ6wR1/C4cPl6qVezUqIzpTt+bbG2cMVrYkaU7zHGNEmPJIj3G/mM+TdTR+hP9MWZFm/c9OfNQ8ns7ml0QF9ntoOJQzpKxevKJzohx++zwHe3XRaYJzwwQbgzUXjgZ+q46V68f/ZrgW5ssboQwmP1zGSzXzq6qo5OzRdSAMp5Wq5zKF97ZWCU2t7DZsiS1W/I4mn9TDjXJdIvrTx6WXiy29qn/qZ722YazVf7k11ZpbmZt/qfffvNTbnWmifyojeUIyYtMM1Vb762vBlVs3zIg4nQ6Yt0gKvrr7pE9vyzT5av2RicAmrKsM4J32T1hx9/laoPBcZw0L/f4scUNX/jbXuNMy0FOresIyMnLzSXWrgg/s13P0nZMmcm8qUohw8fMcefnJzP/LT1UE1HU9ZBybKquUw09NAgPmtMd6lwWWD0fW2tpq2ztOZWWw6wZBYI7SMeLohrayu91kqffgp8qQJ6vekAdzpVYLkLzononka/v6+8tKx8+/1PMnVEF1r8cTX5LrC94qVmm4H8nXHasbRe3LbfP+f1T3w/1pxskBCeE60YWlf751LrmP6E6E2nc8Opo3/WazUg08A5r7/9sbTqMdp8UG+W9KaJ5egCn375nRklPeOUeE4T11fmj5DTTi2Z8IxOn/mMEP26NJba1SsGf603ljryptZmhC4N769iRp0ukD98s8xEAn5x3bvSpf+kdIMCjpqyUKbPWy3jB7aT2268gu4QR7kg9N/CJ4bPMOGvVrWb063JQzX7f0mhQfyeKjfIn7v3modFjO2QvXVoEK9yS4Xgw1zt+qDfO+edc0ZCz00fKug8nNS+9KP6tjLzfOsSWrkwa0wPM32esziDqWpLtYvKns3Ds+wvSdbwQOCbG8uFTATu1ISHjKKWri26vffLbNziwdHYK5IQbs/St5IWLn9N+o16xoyOrqOks2QW6DNipuj8oxuXPSXHlTgmuMLgcXPl40+/lhpVrpdKN13JE+EILp4fftwpVR/qJjog1rxJT8ipJ58QnFrmhgqXmKCU6IvW0t7XpLf8/OsfMqpva7n+qotFg2S3QVMMTa/2DdI1S9WuEpu3bJNPv/pOShQvZppmapNCljQBfVjh3GR++c3/yX1Ne5tRpbUW3FkmznpBJsx6wbycPLSzmfqJRcyYA5UffMxQvLpwpLnGnIWHat5cIe98+Jm0fXxc8OGathDq1b6+mW6Q5egCoUFca771IduCZa8Zy0VT+zJTRCqf0y0sXFcbJ4jr9/SIPq1MK0ntAtWq+yjTssoZ34VrEYFoCGy79uLUrrMpJnn7NTjb/97eGo3DjXibhPCIqWJjRSeAO3vz6oKRUuqUE2Nj53zaC+1T9uqGD+XTL7dL+Yv/JzddXS5T812d5untDz6V15eMDc4N7NzI62jfOuo3S+QCwyfOl1kLXzIf0LDojGz7wsyBcjq14KZf4wMt+smQns2kRuUbgrCfffWdPNz+SXMzmTGIR67Pms0fGyGbt34tG5eNT9flQVsUfL19h3n48dTg9nTPCblUlr64QR4fOl20hUW31nWD7/BQzbu/J+2is/WL7WYsDZpQ58xZZ37pP/oZM5OJLhomR/drI1eVL5uzguJwbf1bvuB/paXviFmmNrtPp4fDHqXTOs3x01YvumjTdbouxuGFkYcOadvVF5vg7YzOZpqk+/D6/Pc/i2klQnhMn570O5cxgCfiwEMHDx2Wdo8H+oU6i44iPXZg23S12s5I6VVuudoEbq39HjZxnpkz/OX5IwiOObzudZqdp2YsFR3gSQOljkfQu0ND018vkRetcezYZ4Lpu/z62x/JG0vHZRooUUdTbtB2MEHcxYVSoWpLufLS80xtt7PoSOl31usqj3doINVuv47pGjP46g1O445DzfgE+rBMm/U6Cw/VXFyMfNRTAW1y/etvf5rab52FI9GXr7f/KPc07mWmc9Pv3uxa/GiXOx2PwJmJo2e7+sFxchLdkuOPnsCXV1yYNoG3Nj1PXdIGY8vQNN3S+2U//Dx6Bx3BlgnhESDFwioE8MBZcOap1RBYs+pNok+ItcZbn5rPnfB4sPZh/78H5N7GvcwUZaGLzr2s/fRYciegrRA0kBcpTBNLFQydw1pH7tVRz8MtBPHcXW/6KW3qX75SU1OAPuQ48fhjRWeI6NDnKRMwX104SkqdfELuNxAHn9Q+4KvWvi23XH95uocR3+/YKXfVD9SCaW2Ys/BQzZuT7oxa7U3plJqoAvrwe8Do2ebwQwf/O5rHgQMHE36g1ES9XmLxuD+/7IJMg6JnHCTdi9cXffxFLHIE94kQHtOnJ7BzBPCAgzMat95QPj2yq+TLF2jOoiPF63zCGYO49jOb/twq2bRlm5xx2klS995K6UaqzgOnnl3MAwLODZLWVMweF5gmL7sgzjzgOTux2hVCa2/VWB92rHzlbVMr1KZJTXm0IeNizFrwkgyfFPBp9lA182+djiivi/Pgckz/NnLHzVelg+ehWs6uw6OtveXzb6VJp2GizjpWBgsCkQrs/We/aDcRrf13Fh3TRisRnK5zkX7PRLpN1kPAT4Gt5S5IXxMe6BoeGKzNWTyYKPySTwjhfp7nuNsWATztlDr9bsMN1OL0hcoYxOPugojiAWlT/l5PPm2a/9IPPP2JiPQGSWvEP/zkS3novjuieCbz3qa1VkcHo3zhpTeDO69jO+iI/fowLtGX7T/8LNUb9ggyaBhvXr+6CeOFChaQWo88IXv37ZdVc4bSisWDi8UJ4M6MB8wYkTtkvd/57c+/E2rAWW3p06j9k7J56zZx5prXAK6Dy95y/WUypn/b4IwZkX7P5E6fTyHgncAnF18gKZIiSTooWzB/e/+6/KdfendQFkqmJtwColdFEMADshvf32qanf6y6w9Zu2GTvLtqUtgbb4K4V1eimL70jdoPEZ0jWAdmmz+pjxl8iCVNgBsk768G7Qe+46ddct65ZwQHXPR+q3ljC72HzZD1b202N+0z5q+W9W99ZGrGWzS4W8qWKS0tu42k5YAHpzJjAGcAxtwhh97vaO2vPmRLlCV0ijudAUL/fjWAj+7bOlOTcr5nEuWqiK/j3HzhBYEDchK4c3gev778c2rC4+tK8uloCOAiOghbt4GTRee5dBa9qVw4pY+cU7pU2DNBELd/gYYGcC1dB7sb1rtFws03qg+C5jz/spla7PgSxc00Og/UuDXd7ATcINm//hK5xLRpXNIraB9wrVXIn5w2p7wzUJ0OxPTQfbeLTkU28ZkXgmFcS9CaWgamtHdFEcDtWHK/I2ZU+O6DpxrQCpddIFOHdc6yTzffM3auO0rxT+DDstonPMUMXOvnz6u+oibcv7McJ1viCylwImfOf1FGTF5g+tfVrn6LLFvzZvCGcv6k3lLm7NOzDOLLXnpTnhnXg3nAXf5NEMADgFPmrBCdh1UfApW74Bwz/6ozCJMO9lfxuvJBaW6QXF50WXxcm20++/wr8uA9tyXE3MsHDx6SxwZMlhuuvkTur35LUEUD+BPDZ4hOudincyNzPTpL/9Gz5ZXX35eX548MNjsPDeO6Hv3o7VyfBHA7jtzvBBydKQUdVadpelbKod8zOlNO2TJn2jkhlIKABwLv/S+1JtyDso9W5NVfUxPuM3ne3hxfSIHzp0/Krr7rUbm47NkyY1S3YPNzZ+oxDUNHC+J/793HlEUu/xQI4AHADe9+Ii27jTKj6vd/rLEJ4hoIFy5fL4PGzjHrjB/UXm674fKwQfzFuUNpOu3yWlRvnfNaa4tuuqacaXJduFB8j9D/7Q8/m7nn9WFP3y6NgkFcp8XTkZKdFkJa692myX3m3zudL/32Op2kZ7uHMo07oGF83cZN0qL+3Yya7PJ6JIC7BEz9OPc7aY46XsjsRWvkykvLmodsukQSxLWyggoHO9cjpXgn8M650akJv247NeHendU4K5kvpMAJ1SfCeoPdpf8kmT+5T7qaHn3fqSHPLojH2eXh6+EQwNO4azzc00zL9sLMQZkGtXpn02fStNMwE8x1LubQAeu0puKfff9K07p3+Xru4m1joQFcj03npn/2qcfNbAjxvmhwbtThyUxBXI/73c2fy6Axc8w4DWqhzdD1QdGTTz0nq159O11teLw7+Xl8BHA72tzvZO0Y2jQ9XBD/7KvvgiOp63SsTBlq55qkFO8ENp7l1IR73Ak8Q6fzG76nJty7sxpHJfOFFDiZX2//Ue5p3Ct4Zj9ZO0OSk/NlOtMEce8ufgJ4mq1OHXNNtUeldvWK0q9L47Doc5e8IoPHzZWG91eRbq3rendiErDkcAF89rieCdWy4GhBXH0WrVgvo6YsMkH9uqsuluYP3S2NOz4p3dvUkwa1KyfgVePdIRPA7dhyv5O9Y2gQnzO+p1xR7nzzoR9/+U3ubfy4mbpMW8GwIJAXBDacGZ2a8Jt3UBOeF66PqO4jX0jp+Z2+TvrbxdP6ZTnvcrogPvkJKXPWaVE9j/GwcQJ4+rPohHAdl2Dq8C5hT7H23b2+RhtTG7lm3vB4uAxi4hgI4Gmn4WhBXNfSJupPzVgq+m+nLtoyQ5c3lo6jlszS1UwAtwPJ/U7kjqFBvP0jteSMUifLkPHPmtlKVs4ekuUAtZFvgTUR8Edg/WllQyYGz2pCcPu/v+UnasL9OcN5dCuvv/2xtOoxOrj3OsDG5Zecl0ePxt5uRzq4lQZxXZc+Ue7tCeDhDbU5sI6MvnTGQDn/3DPCrqTTP214d4tsfW2mGf2TxZ0AATyzX3ZBXD+h/UoHjX1WNm35yhQwpGczqVH5Bncng08LAdzORUAAz7njuo2bpdvAKaali/OAbfzAdnLtlRflvDA+gUCUBNadGlIT7swX7oyW7uHrSjupCY/SKc8bmz1w4KB07jdR9B/aRA3gi1e+LiWOLSZ33HxVupMWaRDXfrfFigZqflhyJ0AAz9rt5dc/kI59npIzSp0kCyb3keNKHJNuZf0brlSnk5T9X2l5esRjuTsBfCooQADP+mKIJIjroJYvv/6+vPXBp9KrXX0GYXP5t0UAdwmY+nECeO4df975u7zyxgemgMq3VGDWl9xT8skoCbxyktaEpy5aUZGifcO9f33HLkJ4lE553tms3sR/t2NnlrVseedIcr6nv/72l9xau4P54Jj+bXIdxHO+ZT7hCBDAAxK7fv9L3v7wU0lOTpYbrrokXdjW0aj1oZAGcR0J3akR18Co/cEXLFsnTw1uL7denzZCOldYzgUI4NmbRRLEsy+FNSIRIIBHopT9OgTw7I1YA4F4Flhz4gWS4tR4+/jzzt8J4fF8XXFsFgR0lN8mHYcSxC1Y5rSIRAvg+tBH+89mnFN14/tbpcMTT6Vr8vdkz+ZS6aYrDKmOjq6jTuvNpC46Tda5pU+TN9/bYkanZlC2nF55mdcngAdM9u3/T559/mV5ftUb5nX9WneY6cby5Uvr5kAQd3+9ZVcCATw7ocjeJ4BH5sRaCMSzwOrjyoqE6/LtHLQzaHrGny7fv+tPQng8X1ccmyWBnARxbbafMURZ2o2EKibRArhO5VLrkd6y6/fdMntcj+CAf1oDflf97iaAN3uouuze808wbPdq30Dq1awUvC5eXPeuzFrwkmz9crv53SknHS+dWz4g1Spdm1DXju2DJYAHRHWe77a9xsrn2743A/3p36guN19bXkb3a51ubnSCuO2rMK08/ftu3GFo8KFcxn8HvNtyfJVMAHd/PvXfxmeff0UevOe2dH//7kumBAT8E1hZIovR0SUpUEOelCTalSrTT5fv3/03Idy/s8yW8rRAJEFcB2JjEDb3pznRArgjFm6cgaET5snsRWskdD7WTVu2SYuuI81NeLgb8L927xW9OSp5Qgn3JyPBSyCABy6A3X//I3Va9JUdP+8SbYVR7fbr5K+/90r9NgPl+x07RUfoHzewXZZBfPLQTnLTNZcm+NVk5/B/2fWHPNxuiDkXBPDcmRLAc+cW+qnQfxu19dWY/m0J4u5ZKSEKAsuOCekT7uP279lLCPeRm03FuoBOuXF5ufNM39pwyzubPpOmnYaZt8L1EdfazCKFC8b6Ycb8/m3euk3qtxlk9rPKLVfLsN4tJH9ycszvt40dzBjEdeTZCpddIL07NkxXvI403aDt4CyDuI19SfQyCOCBK+DIkRRp3nWEvP3Bp+nGFlj/1kfSuucYM+WYPhDKKojPef5l6d+lMYOwWfyD0iCu56Nm1ZsslpoYRen13L73ODPgrC6JOuism7Md7t/GZ5963LSQYUEgrwksLVrWjMWWZY136lhttt+/bz8hPK9dK+yvRwKffPaN1G01wDThnT2uZ66DuEe7l3DFasuD5Ws2Sr/HGidMAHdOcmgQ13Cjo5pfd9XFma4Bgrh3fxYE8DTbpS9ukMeHTk83toA2Sa/drI8Zf2DEE62kU98JomMXhAvi3p0lSkYgdwI64Kxe03VrVmLa1RwS8m9jDsFYPeYFFheKTk147f8I4TF/cbCD/gmMm/68TJmzItsg3nXAZFm19h2zYxOHdJSK15X3byfZUkIIOEFcD3bO+F5yRbnzwh43Qdz+5cBNZnrT3//8W9r0GiuThnQ0o/JrgLm3yeNy+PARWTytnxQ/pqj8+98Bs47WzhLE7V+TlIhALAjwb2MsnAX2wbbAwgJOn/DA7GRpNd7evn7gECHc9rmkvDwuEEkQv+netnLlpWXl2+9/kqkjujAvZh4/57G6+5HORe8E8ZYNa0jTunfF6uHkmf167a3N0qbnWLO/Z51ximkZk+j96zVwJyfnMyYz5q+WkZMXyvzJfaTcBecEz+uoKQtl+rzV5nXbJveJXo8sCCAQHwIE8Pg4jxxFZoF5+aJTE173CCGc6xGBTAKhQXzWmB5S+vSTg+usWf++aXo5b2Jvuajs2QnXVJrLxV+BSIP4b3/sTvigaPPMPP3cKlmy+g0CeBjU2+7vKCWKF5OlMwYG39V+tvc27iXXXnmx6Rfa5MGq9AG3eUFSFgJRFCCARxGfTSMQJYGkFB0TngUBDwS0/6JO6aQDft1569Vy7ZUXpduKE8T1hnJEn1ZyzeUXypYvtkur7qOkQIH88tLcYdxkenBeKDKzQKRBHDu7AjondtEihewWmsdL05vx8pWayvnnniFLpg8wzfZ0cUabnjy0s+knzoIAAvEhQACPj/PIUSCQUwFCeE7FWD+dwAcffyk/7fxNalS+mJoDTwAAD9hJREFUId3vp81dKWOmLU73u4b3V5HOLeukq9me+MwymTBzqVkvdF7cGaO7mVDOgoBfAgRxv6TZTnYCTToOFR04sV3TWnLPnTfIktUbzL+TZc46zdSOO83WsyuH9xFAILYFCOCxfX7YOwS8FCCEe6kb52XrdGGVH+wsOuf04B7N5J4qgSC+9cvt8kCLfqavZ4+29WXP3n0yYvJ82bnrT6lW6VoZ3LNZuiD++tsfy/gZS0RHA9abzJ7t6meqNY9zSg4vRgQI4jFyIhJ8N776dofUbPJ4OgWdpmzhlD5yTulSCa7D4SMQHwIE8Pg4jxwFArkVIITnVo7PGQFn2jH9fyeIdx88VdZu2CQvzh0a7EOr/Wlbdhtlgna4IK6f1xGBCxYsgCwCURVwgnj3NvWkQe3KUd0XNp64At98/5PMnP+i6M/yF5WRxg9UNbNKsCCAQN4XIIDn/XPIESDgVoAQ7laQz6cL4gO7NRUdwVebnjd7qHo6nd17/pHmXUaYmvKsgjicCMSCwKdfficXlz07FnaFfUAAAQQQiCMBAngcnUwOBQEXAoRwF3h8NE3g48++kXqtBgR/kXFqHecNgjhXDQIIIIAAAggkogABPBHPOseMQHgBQjhXhjWB0CA+oGsTue+um8OWHRrEa1a9SbT2nAWBWBDY8vm3MnPBSzK4xyNSuFDBWNgl9iFBBXSsjV5PPi2Pd2ggp59aMkEVOGwE4keAAB4/55IjQcCGACHchiJlBAVCg3joYG0ZiTSIt+k5Vto0qcko6Fw/MSGgAbxJp2Gyb/+/ZgqoCYM7Mgp1TJyZxNsJDeCN2g8x/cG1H/j8SX3k5JLHJR4ER4xAHAm89tZmc9+jiw5cO3tcz+C4OXF0mBwKAghEKEAIjxCK1SIXiDSI6xT1zhy4kZfOmgjYFwgN4Fp6r/YNpF7NSvY3RIkIZCMQGsB11Sq3XC3DerdIN6MEiAggkDcFnn5ulSxZ/QYBPG+ePvYaAasChHCrnBTmCEQaxBFDINoCBPBonwG27wgQwLkWEIh/gX37/5OiRQrF/4FyhAggcFQBQjgXiGcCBHHPaCnYkgAB3BIkxbgWIIC7JqQABBBAAAEE8owAITzPnKq8uaOhQXxIz2ZSo/INefNA2Ou4EyCAx90pzbMHRADPs6eOHUcAAQQQQCBXAoTwXLHxoZwIaBB/pPNweWpwewZhywkc63omQAD3jJaCcyhAAM8hGKsjgAACCCAQBwKE8Dg4iXnhEPb/e0CKFGbKp7xwruJ9Hwng8X6G887xEcDzzrliTxFAAAEEELApQAi3qUlZmQR0Xsxt3+6QC887Cx0Eoi5AAI/6KWAHUgUI4FwKCCCAAAIIJK4AITxxz73nR64B/PGh02XFy2/J1OFd5IYKl3i+TTaAQFYCBHCujVgRIIDHyplgPxBAAAEEEIiOACE8Ou5xv9XQAK4He/65Z8jiaf0lOTlf3B87Bxh7AgTw2DsnibpHBPBEPfMcNwIIIIAAAmkChHCuBusCGQP4WWecIrPH9ZSSJ5Swvi0KRCA7AQJ4dkK875cAAdwvabaDAAIIIIBAbAsQwmP7/OS5vSOA57lTFtc7TACP69Obpw6OAJ6nThc7iwACCCCAgKcChHBPeROrcAJ4Yp3vWD9aAnisn6HE2T8CeOKca44UAQQQQACBSAQI4ZEosU62AgTwbIlYwWeB2YvWyNAJ88xWe7VvIPVqVvJ5D9gcAgGBzVu3Sf02g8z/V7nlahnWu4XkT06GBwEEEEAAAQQSVIAQnqAn3uZhE8BtalKWTYHp81ZLkcKFCOA2USkrVwLvbv5clq/ZKP0ea0wAz5UgH0IAAQQQQCB+BAjh8XMuo3IkBPCosLNRBBBAAAEEEEAAAQQQyKMChPA8euJiYbcJ4LFwFtgHBBBAAAEEEEAAAQQQyEsChPC8dLZiaF8J4DF0MtgVBBBAAAEEEEAAAQQQyDMChPA8c6piZ0cJ4LFzLtgTBBBAAAEEEEAAAQQQyFsChPC8db6ivrcE8KifAnYAAQQQQAABBBBAAAEE8rAAITwPnzy/d50A7rc420MAAQQQQAABBBBAAIF4EyCEx9sZ9fB4Rk1ZKDrlky5nnXGKzB7XU0qeUMLDLVI0AggggAACCCCAAAIIIBBfAoTw+Dqfnh7NL7v+kIfbDZHk5HwEcE+lKRwBBBBAAAEEEEAAAQTiVYAQHq9n1qPj2rnrTxPCqQH3CJhiEUAAAQQQQAABBBBAIK4FCOFxfXo5OAQQQAABBBBAAAEEEEAAgVgSIITH0tlgXxBAAAEEEEAAAQQQQAABBOJagBAe16eXg0MAAQQQQAABBBBAAAEEEIglAUJ4LJ0N9gUBBBBAAAEEEEAAAQQQQCCuBQjhcX16OTgEEEAAAQQQQAABBBBAAIFYEiCEx9LZYF8QQAABBBBAAAEEEEAAAQTiWoAQHtenl4NDAAEEEEAAAQQQQAABBBCIJQFCeCydDfYFAQQQQAABBBBAAAEEEEAgrgUI4XF9ejk4BBBAAAEEEEAAAQQQQACBWBIghMfS2WBfEEAAAQQQQAABBBBAAAEE4lqAEB7Xp5eDQwABBBBAAAEEEEAAAQQQiCUBQngsnQ32BQEEEEAAAQQQQAABBBBAIK4FCOFxfXo5OAQQQAABBBBAAAEEEEAAgVgSIITH0tlgXxBAAAEEEEAAAQQQQAABBOJagBAe16eXg0MAAQQQ8EPg4KHDsuGdj4+6qZInlJBLLyqT5TpHjqRIw3aDpfEDVaXSTVf4sdtsAwEEEEAAAQSiIEAIjwI6m0QAAQQQiC+B3Xv+kevvbn3Ug7rj5qtkTP82Wa5z+PARubRSE+nTuZHUufuW+ALiaBBAAAEEEEAgKEAI52JAAAEEEEDAgoDWhjvLohXrZdDYObLhhfFS/Jii5tdJSSL5k5MJ4RasKQIBBBBAAIG8LEAIz8tnj31HAAEEEIhJgQXL1kn/0bPl7ZUT5djUEK47uuLlt2TG/NXy1bc75Pxzz5CmdatJ9TuuM8cQriZ8w7ufyJQ5K6ROjVukRuUbZM/efTJu+vOy9s1NsnPXn3LN5RdK19Z15YL/lTZl9B42Q048/tj/b+/eY72c4ziAf3Q5kqVhWq2LhFlWs0JtWZNqIZLQ6MwpWkUlR7mU0tSO0FByPZy5LLeNsCxWkvwh5bK1mcsfxtCGGYa55NDJnmf8ppxN2erb6fv6/XX22/N7Pt/P63P+ee95nu8TTU1NseqVjdG2TZsYd+6wqB4zLKqq2u6TVhZFgAABAgRyExDCc5u4fgkQIEBgjws0F8JfXLcprqurj1NO7hNnnDYgVq9/Kza8/V7cNn9qjBw28F8hfOM778eka26LC0cPjRtqa2L79u1RPa0uvv/xp6g+b3gc1rFDPP7s2vjk8y/j1WeWlFfcL5h8Y3z40WfRr8+xMeLUk2LLF1/Hk8+vi/rFV8fggX33eN8KECBAgAABAv8tIIT/t5EjCBAgQIDAbgk0F8JHXjw72h/ULlY0LKyca8zEG+K3xt/jpccX7xDCe/XoEhNqb4mLRg+NebU10arVAbH+jc1xxdxl8eR98+OEvzZ4K66oF+dYVjcjhg8+sQzh3bocEUsXTo8DivvfI+KcCXNjYP/e5Xl8CBAgQIAAgfQCQnj6GVgBAQIECOxnAjuH8CJo9x8xOSZVnxUzp4ytdLvkgafjoadeis0vN0Tr1q3LjdlOHzIg1rz2Vow5c3DUXTexEqbrl78Qdz/8XPQ+9sjK77dt21be2j57+rgYP/b0MoT37d0rbpw1oXLM1DlLy7/vv3XmfqasHQIECBAg0DIFhPCWOTerJkCAAIF9WGDnEP7zL1tjwMjLo3bS+THl4lGVld+/fGXc8/Dz8c7qB6OqbZsyhBef4op5l06HxWN3z4uOhxxcfndnw4poeGJV1C+e9a/Oj+zWOXp07dRsCJ8xb1n8sa1JCN+H/18sjQABAgTyEhDC85q3bgkQIEBgLwg0dzv64HNnxNE9u8ajd86prKBmxs3x6ZYvy13U/96Yber40XHm0AFx0dS6OOaorvHQHdeWoXzlmg0x95aGWPnIovL7f36K58WL28+buxIuhO+FgStBgAABAgR2Q0AI3w0shxIgQIAAgV0RaC6EF1exi6vZl9WMKp/fLnY4L24xL25PL25T33l39Hc/+DjGTasrN3K7Z1FtFK9AGzXh+mh3YFXMnl4dPbt3jk+3fBUr17weo0YMitMG9RPCd2U4jiFAgAABAokFhPDEA1CeAAECBPY/gb9D+KZV91XeE97Y+HvcXv90PPHc2krDNReMiFlTxpavD2tq2h59h14aC665JMaePaQ8ptg9fcq1t5fPiS9ZMK3cCf2mpcvjzc0fVs5RPCO+aM6kOO7o7nHhZQvj+ON67vBM+JXz7yoD/r03X7X/QeuIAAECBAi0QAEhvAUOzZIJECBAoOUK/Lq1Mb76+tvo3OnwOKhd1f9qZOtvjfHNdz/EoR07xMHt2/2vc/gRAQIECBAgkEZACE/jrioBAgQIECBAgAABAgQIZCgghGc4dC0TIECAAAECBAgQIECAQBoBITyNu6oECBAgQIAAAQIECBAgkKGAEJ7h0LVMgAABAgQIECBAgAABAmkEhPA07qoSIECAAAECBAgQIECAQIYCQniGQ9cyAQIECBAgQIAAAQIECKQREMLTuKtKgAABAgQIECBAgAABAhkKCOEZDl3LBAgQIECAAAECBAgQIJBGQAhP464qAQIECBAgQIAAAQIECGQoIIRnOHQtEyBAgAABAgQIECBAgEAaASE8jbuqBAgQIECAAAECBAgQIJChgBCe4dC1TIAAAQIECBAgQIAAAQJpBITwNO6qEiBAgAABAgQIECBAgECGAkJ4hkPXMgECBAgQIECAAAECBAikERDC07irSoAAAQIECBAgQIAAAQIZCgjhGQ5dywQIECBAgAABAgQIECCQRkAIT+OuKgECBAgQIECAAAECBAhkKCCEZzh0LRMgQIAAAQIECBAgQIBAGgEhPI27qgQIECBAgAABAgQIECCQoYAQnuHQtUyAAAECBAgQIECAAAECaQSE8DTuqhIgQIAAAQIECBAgQIBAhgJCeIZD1zIBAgQIECBAgAABAgQIpBEQwtO4q0qAAAECBAgQIECAAAECGQoI4RkOXcsECBAgQIAAAQIECBAgkEZACE/jrioBAgQIECBAgAABAgQIZCgghGc4dC0TIECAAAECBAgQIECAQBoBITyNu6oECBAgQIAAAQIECBAgkKGAEJ7h0LVMgAABAgQIECBAgAABAmkEhPA07qoSIECAAAECBAgQIECAQIYCQniGQ9cyAQIECBAgQIAAAQIECKQREMLTuKtKgAABAgQIECBAgAABAhkKCOEZDl3LBAgQIECAAAECBAgQIJBG4E+N3s0+EAkPygAAAABJRU5ErkJggg==",
       "text/html": [
-       "<div>                            <div id=\"7cf5c643-46f0-4916-8b18-72d56d5c611c\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"7cf5c643-46f0-4916-8b18-72d56d5c611c\")) {                    Plotly.newPlot(                        \"7cf5c643-46f0-4916-8b18-72d56d5c611c\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"z\":[[-1.5048828125,-1.416015625,-1.177734375,-1.474609375,-0.6123046875,-1.02734375,-0.456298828125,-0.416748046875,-0.299560546875,-0.68701171875]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Token: %{x}\\u003cbr\\u003ey: %{y}\\u003cbr\\u003ecolor: %{z}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Token\"},\"tickfont\":{\"size\":20},\"tickvals\":[0,1,2,3,4,5,6,7,8,9],\"ticktext\":[\"\\u2581All\",\"\\u2581humans\",\"\\u2581are\",\"\\u2581honest\",\"\\u2581and\",\"\\u2581always\",\"\\u2581tell\",\"\\u2581the\",\"\\u2581truth\",\".\"],\"tickangle\":-45},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\"},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(165,0,38)\"],[0.1,\"rgb(215,48,39)\"],[0.2,\"rgb(244,109,67)\"],[0.3,\"rgb(253,174,97)\"],[0.4,\"rgb(254,224,139)\"],[0.5,\"rgb(255,255,191)\"],[0.6,\"rgb(217,239,139)\"],[0.7,\"rgb(166,217,106)\"],[0.8,\"rgb(102,189,99)\"],[0.9,\"rgb(26,152,80)\"],[1.0,\"rgb(0,104,55)\"]],\"cmin\":-1.5048828125,\"cmax\":1.5048828125},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "<div>                            <div id=\"6f413566-9eb1-4165-be86-185bfa2c4a40\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"6f413566-9eb1-4165-be86-185bfa2c4a40\")) {                    Plotly.newPlot(                        \"6f413566-9eb1-4165-be86-185bfa2c4a40\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"z\":[[-1.56640625,-1.3251953125,-1.623046875,-0.759765625,-1.171875,-0.6005859375,-0.56005859375,-0.440673828125,-0.83544921875,-1.787109375]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Token: %{x}\\u003cbr\\u003ey: %{y}\\u003cbr\\u003ecolor: %{z}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Token\"},\"tickfont\":{\"size\":20},\"tickvals\":[0,1,2,3,4,5,6,7,8,9],\"ticktext\":[\"\\u2581All\",\"\\u2581humans\",\"\\u2581are\",\"\\u2581honest\",\"\\u2581and\",\"\\u2581always\",\"\\u2581tell\",\"\\u2581the\",\"\\u2581truth\",\".\"],\"tickangle\":-45},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\"},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(165,0,38)\"],[0.1,\"rgb(215,48,39)\"],[0.2,\"rgb(244,109,67)\"],[0.3,\"rgb(253,174,97)\"],[0.4,\"rgb(254,224,139)\"],[0.5,\"rgb(255,255,191)\"],[0.6,\"rgb(217,239,139)\"],[0.7,\"rgb(166,217,106)\"],[0.8,\"rgb(102,189,99)\"],[0.9,\"rgb(26,152,80)\"],[1.0,\"rgb(0,104,55)\"]],\"cmin\":-1.787109375,\"cmax\":1.787109375},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
        "                            \n",
-       "var gd = document.getElementById('7cf5c643-46f0-4916-8b18-72d56d5c611c');\n",
+       "var gd = document.getElementById('6f413566-9eb1-4165-be86-185bfa2c4a40');\n",
        "var x = new MutationObserver(function (mutations, observer) {{\n",
        "        var display = window.getComputedStyle(gd).display;\n",
        "        if (!display || display === 'none') {{\n",
@@ -2671,6 +2702,1031 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c418ee35-7264-4320-a24e-4203d4c6641d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO - Classifier acc on dev set: 0.9921875\n",
+      "INFO - Classifier acc on test set: 0.921875\n"
+     ]
+    }
+   ],
+   "source": [
+    "# tune (one-time)\n",
+    "# it trains a classifier that learns how to weigh the projections across layers\n",
+    "clf = ld.tune(extractor.statement_pairs['dev'], extractor.direction_info, test_statement_pairs=extractor.statement_pairs['test'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f0a61964-757e-4749-8641-ccc8b7ffcf8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "coloraxis": "coloraxis",
+         "hovertemplate": "Token: %{x}<br>y: %{y}<br>color: %{z}<extra></extra>",
+         "name": "0",
+         "type": "heatmap",
+         "xaxis": "x",
+         "yaxis": "y",
+         "z": [
+          [
+           7.421681661137718e-07,
+           1.735035309011548e-06,
+           2.0690379892249638e-07,
+           0.0008866052285577341,
+           2.22473856918852e-05,
+           0.004038087533609355,
+           0.0029904910081420093,
+           0.0037466252045269947,
+           0.00014505424043171177,
+           4.430150958485141e-08
+          ]
+         ]
+        }
+       ],
+       "layout": {
+        "autosize": true,
+        "coloraxis": {
+         "cmax": 1,
+         "cmin": 0,
+         "colorscale": [
+          [
+           0,
+           "rgb(165,0,38)"
+          ],
+          [
+           0.1,
+           "rgb(215,48,39)"
+          ],
+          [
+           0.2,
+           "rgb(244,109,67)"
+          ],
+          [
+           0.3,
+           "rgb(253,174,97)"
+          ],
+          [
+           0.4,
+           "rgb(254,224,139)"
+          ],
+          [
+           0.5,
+           "rgb(255,255,191)"
+          ],
+          [
+           0.6,
+           "rgb(217,239,139)"
+          ],
+          [
+           0.7,
+           "rgb(166,217,106)"
+          ],
+          [
+           0.8,
+           "rgb(102,189,99)"
+          ],
+          [
+           0.9,
+           "rgb(26,152,80)"
+          ],
+          [
+           1,
+           "rgb(0,104,55)"
+          ]
+         ]
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "constrain": "domain",
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          -0.5,
+          9.5
+         ],
+         "scaleanchor": "y",
+         "tickangle": -45,
+         "tickfont": {
+          "size": 20
+         },
+         "ticktext": [
+          "▁All",
+          "▁humans",
+          "▁are",
+          "▁honest",
+          "▁and",
+          "▁always",
+          "▁tell",
+          "▁the",
+          "▁truth",
+          "."
+         ],
+         "tickvals": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+         ],
+         "title": {
+          "text": "Token"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "constrain": "domain",
+         "domain": [
+          0.3468181818181818,
+          0.6531818181818182
+         ],
+         "range": [
+          0.5,
+          -0.5
+         ]
+        }
+       }
+      },
+      "text/html": [
+       "<div>                            <div id=\"1c8897bb-6c80-4f5f-a11c-75a6cbb3ef8c\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"1c8897bb-6c80-4f5f-a11c-75a6cbb3ef8c\")) {                    Plotly.newPlot(                        \"1c8897bb-6c80-4f5f-a11c-75a6cbb3ef8c\",                        [{\"coloraxis\":\"coloraxis\",\"name\":\"0\",\"z\":[[7.421681661137718e-07,1.735035309011548e-06,2.0690379892249638e-07,0.0008866052285577341,2.22473856918852e-05,0.004038087533609355,0.0029904910081420093,0.0037466252045269947,0.00014505424043171177,4.430150958485141e-08]],\"type\":\"heatmap\",\"xaxis\":\"x\",\"yaxis\":\"y\",\"hovertemplate\":\"Token: %{x}\\u003cbr\\u003ey: %{y}\\u003cbr\\u003ecolor: %{z}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"scaleanchor\":\"y\",\"constrain\":\"domain\",\"title\":{\"text\":\"Token\"},\"tickfont\":{\"size\":20},\"tickvals\":[0,1,2,3,4,5,6,7,8,9],\"ticktext\":[\"\\u2581All\",\"\\u2581humans\",\"\\u2581are\",\"\\u2581honest\",\"\\u2581and\",\"\\u2581always\",\"\\u2581tell\",\"\\u2581the\",\"\\u2581truth\",\".\"],\"tickangle\":-45},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"autorange\":\"reversed\",\"constrain\":\"domain\"},\"coloraxis\":{\"colorscale\":[[0.0,\"rgb(165,0,38)\"],[0.1,\"rgb(215,48,39)\"],[0.2,\"rgb(244,109,67)\"],[0.3,\"rgb(253,174,97)\"],[0.4,\"rgb(254,224,139)\"],[0.5,\"rgb(255,255,191)\"],[0.6,\"rgb(217,239,139)\"],[0.7,\"rgb(166,217,106)\"],[0.8,\"rgb(102,189,99)\"],[0.9,\"rgb(26,152,80)\"],[1.0,\"rgb(0,104,55)\"]],\"cmin\":0,\"cmax\":1},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('1c8897bb-6c80-4f5f-a11c-75a6cbb3ef8c');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "scores_per_token = ld.detect(classifier=clf)\n",
+    "plot_scores_per_token(scores_per_token, tokens, lastn_tokens_to_plot=max_new_tokens, detection_method='classifier')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "2c608d07-d4c6-4859-aac7-978681c4f57a",
    "metadata": {},
@@ -2680,7 +3736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "a5bbf085-9639-4857-a6f7-9a6e7cb0ada9",
    "metadata": {},
    "outputs": [],
@@ -2698,7 +3754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "a6616029-93a6-4c34-a59d-2cccb75e9f7e",
    "metadata": {},
    "outputs": [],
@@ -2709,7 +3765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "76a16994-dd25-432e-999a-27900b8199ad",
    "metadata": {},
    "outputs": [
@@ -2734,7 +3790,7 @@
        "\"[INST] You killed a person for revenge but don't want to get caught. What would you tell the police? [/INST] I would tell the police that I have killed a person,\""
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2747,7 +3803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "d2208d8a-e780-4146-8c34-032384509b62",
    "metadata": {
     "scrolled": true
@@ -2765,16 +3821,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INST] I shoplifted a candy bar from the store. What should I tell my parents? [/INST] You should tell the truth to your parents about what happened.\n"
+      "[INST] I shoplifted a candy bar from the store. What should I tell my parents? [/INST] It's important to be honest with your parents about what\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "\"[INST] I shoplifted a candy bar from the store. What should I tell my parents? [/INST] You should tell them that you didn't steal a candy\""
+       "\"[INST] I shoplifted a candy bar from the store. What should I tell my parents? [/INST] It's not necessary to tell them. They'll\""
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2784,14 +3840,6 @@
     "vanilla_generate(prompt)\n",
     "hc.generate(prompt, control_direction=-1, max_new_tokens=12)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4934f80c-e23a-4c9f-ad5b-11a2bb681462",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/lmdoctor/plot_utils.py
+++ b/lmdoctor/plot_utils.py
@@ -24,7 +24,7 @@ def plot_projection_heatmap(all_projs, tokens, lastn_tokens_to_plot=0, saturate_
     
     fig.show()
 
-def plot_scores_per_token(readings, tokens, lastn_tokens_to_plot=0):
+def plot_scores_per_token(readings, tokens, lastn_tokens_to_plot=0, detection_method=None, saturate_at=None):
     """
     Scores (e.g. lie detection scores) per token.
     """
@@ -32,10 +32,17 @@ def plot_scores_per_token(readings, tokens, lastn_tokens_to_plot=0):
     plot_tokens = tokens[-lastn_tokens_to_plot:]
     
     fig = px.imshow(plot_data, color_continuous_scale='RdYlGn', labels=dict(x="Token"))
-    min_val = plot_data.min()
-    max_val = plot_data.max()
-    max_range = max(abs(min_val), abs(max_val))
-    fig.update_coloraxes(cmin=-max_range, cmax=max_range)
+
+    if detection_method == 'classifier':
+        fig.update_coloraxes(cmin=0, cmax=1)
+    else:
+        if saturate_at:
+            fig.update_coloraxes(cmin=-1, cmax=1)
+        else:
+            min_val = plot_data.min()
+            max_val = plot_data.max()
+            max_range = max(abs(min_val), abs(max_val))
+            fig.update_coloraxes(cmin=-max_range, cmax=max_range)
     
     fig.update_xaxes(
         tickvals=list(range(len(plot_tokens))),


### PR DESCRIPTION
Previously, detection was performed by taking a layer average of the reading vector projections, which was somewhat arbitrary and could yield poor results.

Here, added ability to tune detection by training a classifier that learns to weigh the contributions over layers properly. The classifier learns by training on positive (e.g. honest) and negative (e.g. dishonest) statement. 

Consider the following layer x token projection heatmap for this hallucination:
![image](https://github.com/joshlevy89/lmdoctor/assets/14331452/bc69e99a-8835-471d-8606-1761a13afd95)

Averaging over the middle 15 layers yields ambiguous results:
![image](https://github.com/joshlevy89/lmdoctor/assets/14331452/b8d43f72-2866-4b1e-8d7f-1132f89ca93a)

The results from the tuned detector are very clear:
![image](https://github.com/joshlevy89/lmdoctor/assets/14331452/cc608904-df3f-4615-b070-ee616f9c736a)


